### PR TITLE
WPF-839927-XAML code was not updated properly in RibbonMerge

### DIFF
--- a/wpf/Ribbon/RibbonMerge.md
+++ b/wpf/Ribbon/RibbonMerge.md
@@ -149,10 +149,9 @@ Child View 2
 </UserControl>
    
 {% endhighlight %}
-
 {% endtabs %}
 {% endcapture %}
-{{ codesnippet3 | OrderList_Indent_Level_2 }}
+{{ codesnippet3 | OrderList_Indent_Level_1 }}
 
  3. Now, add the both child view's into the [DocumentContainer](https://help.syncfusion.com/cr/wpf/Syncfusion.Tools.Wpf~Syncfusion.Windows.Tools.Controls.DocumentContainer.html) and set the the [DocumentContainer.MDIParentRibbon](https://help.syncfusion.com/cr/wpf/Syncfusion.Tools.Wpf~Syncfusion.Windows.Tools.Controls.DocumentContainer~MDIParentRibbon.html) property of [DocumentContainer](https://help.syncfusion.com/cr/wpf/Syncfusion.Tools.Wpf~Syncfusion.Windows.Tools.Controls.DocumentContainer.html).
 

--- a/wpf/SpellChecker/custom-dictionary-support.md
+++ b/wpf/SpellChecker/custom-dictionary-support.md
@@ -124,7 +124,7 @@ private void SpellCheck_ButtonClick(object sender, RoutedEventArgs e) {
 {% endhighlight %}
 {% endtabs %}
 {% endcapture %}
-{{ codesnippet2 | OrderList_Indent_Level_2 }}
+{{ codesnippet2 | OrderList_Indent_Level_1 }}
 
 N> You can add multiple `HunspellDictionary` with various culture files into the `SfSpellChecker.Dictionaries` collection. Based on the `SfSpellChecker.Culture` respective `HunspellDictionary` is used for spell check.
 


### PR DESCRIPTION
### Description
Changed the end tab for the code snippet in RibbonMerge.md and CustomDictionary.md file.

Before Changes:

https://help.syncfusion.com/wpf/spellchecker/custom-dictionary-support?cs-save-lang=1&cs-lang=csharp 
<img width="534" alt="image" src="https://github.com/syncfusion-content/wpf-docs/assets/102575025/46e57005-5f52-4ed3-8883-441cb1a6c9a9">

https://help.syncfusion.com/wpf/ribbon/ribbonmerge 
<img width="544" alt="image" src="https://github.com/syncfusion-content/wpf-docs/assets/102575025/79c14e0f-dde9-4985-9b4e-126729b5b4a1">
