### PR TITLE
WPF-865353 - How to localize when resource file present in different assembly or default namespace is not same as assembly name

### DIFF
--- a/wpf/Spreadsheet/Localization.md
+++ b/wpf/Spreadsheet/Localization.md
@@ -72,7 +72,8 @@ In  [WPF-Spreadsheet](https://help.syncfusion.com/wpf/spreadsheet/getting-starte
  public MainWindow()
  {
       System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo("ja");
-      Syncfusion.UI.Xaml.Spreadsheet.Resources.GridResourceWrapper.SetResources(assemblyname, "namespacename");
+      Assembly assembly = Assembly.Load("Another assemblyname having resource file");
+      Syncfusion.UI.Xaml.Spreadsheet.Resources.GridResourceWrapper.SetResources(assembly, "namespacename");
       InitializeComponent();
  }
 {% endhighlight %}

--- a/wpf/Spreadsheet/Localization.md
+++ b/wpf/Spreadsheet/Localization.md
@@ -62,3 +62,18 @@ Now, the default localized strings can be modified by changing the Name/Value pa
 
 
 N> You can refer to our [WPF Spreadsheet](https://www.syncfusion.com/wpf-controls/spreadsheet) feature tour page for its groundbreaking feature representations. You can also explore our [WPF Spreadsheet example](https://github.com/syncfusion/wpf-demos) to know how to render and configure the spreadsheet.
+
+## Localize when the resource file present in different assembly or different namespace?
+
+In  [WPF-Spreadsheet](https://help.syncfusion.com/wpf/spreadsheet/getting-started) (SfSpreadsheet) reads the localization resource files based on assembly name from its default namespace. If you are having the localization resource file other than the executing assembly (Assembly.GetExecutingAssembly())or other than default namespace, then you have to pass the assembly having the resource file and it’s default namespace to [Syncfusion.UI.Xaml.Spreadsheet.Resources.GridResourceWrapper.SetResources](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.Spreadsheet.Resources.GridResourceWrapper.html#Syncfusion_UI_Xaml_Spreadsheet_Resources_GridResourceWrapper_SetResources_System_Reflection_Assembly_System_String_) method.
+
+{% tabs %}
+{% highlight c# %}
+ public MainWindow()
+ {
+      System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo("ja");
+      Syncfusion.UI.Xaml.Spreadsheet.Resources.GridResourceWrapper.SetResources(assemblyname, "namespacename");
+      InitializeComponent();
+ }
+{% endhighlight %}
+{% endtabs %}

--- a/wpf/Spreadsheet/Localization.md
+++ b/wpf/Spreadsheet/Localization.md
@@ -63,9 +63,9 @@ Now, the default localized strings can be modified by changing the Name/Value pa
 
 N> You can refer to our [WPF Spreadsheet](https://www.syncfusion.com/wpf-controls/spreadsheet) feature tour page for its groundbreaking feature representations. You can also explore our [WPF Spreadsheet example](https://github.com/syncfusion/wpf-demos) to know how to render and configure the spreadsheet.
 
-## Localize when the resource file present in different assembly or different namespace?
+## Localize when the resource file is present in a different assembly or different namespace
 
-In  [WPF-Spreadsheet](https://help.syncfusion.com/wpf/spreadsheet/getting-started) (SfSpreadsheet) reads the localization resource files based on assembly name from its default namespace. If you are having the localization resource file other than the executing assembly (Assembly.GetExecutingAssembly())or other than default namespace, then you have to pass the assembly having the resource file and it’s default namespace to [Syncfusion.UI.Xaml.Spreadsheet.Resources.GridResourceWrapper.SetResources](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.Spreadsheet.Resources.GridResourceWrapper.html#Syncfusion_UI_Xaml_Spreadsheet_Resources_GridResourceWrapper_SetResources_System_Reflection_Assembly_System_String_) method.
+[WPF-Spreadsheet](https://help.syncfusion.com/wpf/spreadsheet/getting-started) (SfSpreadsheet) reads the localization resource files based on the assembly name from its default namespace. If you have the localization resource file other than the executing assembly (Assembly.GetExecutingAssembly())or other than the default namespace, then you have to pass the assembly having the resource file and its default namespace to [GridResourceWrapper.SetResources](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.Spreadsheet.Resources.GridResourceWrapper.html#Syncfusion_UI_Xaml_Spreadsheet_Resources_GridResourceWrapper_SetResources_System_Reflection_Assembly_System_String_) method.
 
 {% tabs %}
 {% highlight c# %}


### PR DESCRIPTION
Task Link : https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/865353 

**Description :**

I have created a user guide documentation to localize when a resource file is present in a different assembly or namespace.

