### PR TITLE
ES-861062 Need to add notes for DataBinding page in WPF SfDataGrid

### DIFF
--- a/wpf/DataGrid/Data-Binding.md
+++ b/wpf/DataGrid/Data-Binding.md
@@ -102,6 +102,7 @@ All the data operations (sorting, grouping, filtering and etc.) are supported wh
 ### Limitations when binding indexer property 
 
 * SfDataGrid doesn’t support [LiveDataUpdateMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.Grid.SfDataGrid.html#Syncfusion_UI_Xaml_Grid_SfDataGrid_LiveDataUpdateMode) - `AllowDataShaping` and `AllowSummaryUpdate`.
+* SfDataGrid doesn’t support [AutoGenerateColumns](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.Grid.SfGridBase.html#Syncfusion_UI_Xaml_Grid_SfGridBase_AutoGenerateColumns).
 
 
 ## Defining source data type


### PR DESCRIPTION
### Description ###
[ES-861062 Need to add notes for DataBinding page in WPF SfDataGrid](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/861062).

Regarding this ticket [Can indexed columns be auto-generated in the WPF SfDataGrid control](https://support.syncfusion.com/agent/tickets/529172) I have added the limitation for binding indexer property in WPF SfDataGrid 