### PR TITLE
Restricted the RowHeight and ColumnWidth values in TileView Virtualization

### DIFF
--- a/wpf/Tile-View/Data-Binding-Support.md
+++ b/wpf/Tile-View/Data-Binding-Support.md
@@ -154,7 +154,7 @@ N> [View Sample in GitHub](https://github.com/SyncfusionExamples/syncfusion-wpf-
 
 ## Virtualization support
 
-You can enable the UI virtualization support in `TileViewControl`, which allows the users to load large sets of data without affecting loading or scrolling performance by setting the [IsVirtualizing](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Shared.TileViewControl.html#Syncfusion_Windows_Shared_TileViewControl_IsVirtualizing) property value as `true`. This feature allows users to reduce the loading time of `TileView` items regardless of items count. The default value of `IsVirtualizing` property is `false`. 
+You can enable the UI virtualization support in `TileViewControl`, which allows the users to load large sets of data without affecting loading or scrolling performance by setting the [IsVirtualizing](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Shared.TileViewControl.html#Syncfusion_Windows_Shared_TileViewControl_IsVirtualizing) property value as `true`. This feature allows users to reduce the loading time of `TileView` items regardless of items count. The default value of `IsVirtualizing` property is `false`. When using virtualization, it's recommended to use RowCount and ColumnCount instead of RowHeight and ColumnWidth. RowHeight and ColumnWidth won't work with virtualization, and the layout will be updated based on RowCount and ColumnCount.
 
 {% tabs %}
 {% highlight XAML %}


### PR DESCRIPTION
### Description

Restricted the RowHeight and ColumnWidth values in TileView Virtualization. So we have updated the documentation for TileViewControl.