### PR TITLE
UG documentation on disabling the Undo/redo operation in WPF PDFViewer

### DIFF
--- a/wpf-toc.html
+++ b/wpf-toc.html
@@ -1535,6 +1535,7 @@
 					<li><a href="/wpf/Pdf-Viewer/toggling-visibility-of-the-scroll-bar">Toggle visibility of the scroll bar</a></li>
 					<li><a href="/wpf/Pdf-Viewer/acquiring-current-page-being-displayed">Acquire current page being displayed</a></li>
 					<li><a href="/wpf/Pdf-Viewer/enabling-and-disabling-notification-bar">Enable and Disable Notification bar</a></li>
+					<li><a href="/wpf/Pdf-Viewer/how-to/Disable-the-Undo-Redo-operation">Disable the Undo Redo operation</a></li>
                 </ul>
             </li>
         </ul>

--- a/wpf/Pdf-Viewer/How-To/Disable-the-Undo-Redo-operation.md
+++ b/wpf/Pdf-Viewer/How-To/Disable-the-Undo-Redo-operation.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title: Disable the Undo Redo operation in PdfViewer | Syncfusion
+description: Learn about how to Disable the Undo Redo operation in Syncfusion WPF Pdf Viewer control using UndoRedoSettings.
+platform: wpf
+control: PDF Viewer
+documentation: ug
+---
+
+# Disable the Undo Redo operation 
+
+To disable the Undo Redo operation, set the Limit property of UndoRedoSettings to zero. By default, this value is set to 100. Reducing the value to zero will disable the Undo Redo functionality. The following code example demonstrates how to set the Limit value:
+
+{% tabs %}
+{% highlight C# %}
+
+//Initialize PDF Viewer.
+PdfViewerControl pdfViewer = new PdfViewerControl();
+//Set Limit property as zero
+pdfViewer.UndoRedoSettings.Limit = 0;
+//Load the PDF.
+pdfViewer.Load("Sample.pdf");
+
+
+{% endhighlight %}
+
+
+
+{% highlight vbnet %}
+
+'Initialize PDF Viewer.
+Private pdfViewer As New PdfViewerControl()
+'Set Limit property as zero
+pdfViewer.UndoRedoSettings.Limit = 0
+'Load the PDF.
+pdfViewer.Load("Sample.pdf")
+
+
+{% endhighlight %}
+{% endtabs %}


### PR DESCRIPTION
Refer --[UG documentation on disabling the Undo/redo operation in WPF PDFViewer by Yaminisrisf4389 · Pull Request #1528 · syncfusion-content/wpf-docs](https://github.com/syncfusion-content/wpf-docs/pull/1528)