### PR TITLE
WPF-924506-Trademark_Symbol_Inclusion_WPF

### DIFF
--- a/wpf/Diagram/Annotation/Interaction/Rotating.md
+++ b/wpf/Diagram/Annotation/Interaction/Rotating.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Annotation Rotation | Syncfusion 
-description: how to rotate the annotations in Syncfusion Essential Studio WPF Diagram (SfDiagram) control, its elements, and more.
+description: how to rotate the annotations in Syncfusion Essential Studio® WPF Diagram (SfDiagram) control, its elements, and more.
 platform: wpf
 control: SfDiagram
 documentation: ug

--- a/wpf/HeatMap/ColorMapping.md
+++ b/wpf/HeatMap/ColorMapping.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ColorMapping in WPF HeatMap (SfHeatMap) control | Syncfusion
-description: How to configure colors codes for Syncfusion Essential Studio WPF HeatMap (SfHeatMap) control, its elements and more.
+description: How to configure colors codes for Syncfusion Essential Studio® WPF HeatMap (SfHeatMap) control, its elements and more.
 platform: wpf
 control: SfHeatMap
 documentation: ug

--- a/wpf/HeatMap/ItemsMapping.md
+++ b/wpf/HeatMap/ItemsMapping.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: ItemsMapping in WPF HeatMap (SfHeatMap) control | Syncfusion
-description: Learn here about ItemsMapping in Syncfusion Essential Studio WPF HeatMap (SfHeatMap) control, its elements and more.
+description: Learn here about ItemsMapping in Syncfusion Essential Studio® WPF HeatMap (SfHeatMap) control, its elements and more.
 platform: wpf
 control: SfHeatMap
 documentation: ug

--- a/wpf/HeatMap/Legend.md
+++ b/wpf/HeatMap/Legend.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Legend in WPF HeatMap (SfHeatMap) control | Syncfusion
-description: How to create and configure legend for Syncfusion Essential Studio WPF HeatMap (SfHeatMap) control, its elements and more.
+description: How to create and configure legend for Syncfusion Essential Studio® WPF HeatMap (SfHeatMap) control, its elements and more.
 platform: wpf
 control: SfHeatMap
 documentation: ug

--- a/wpf/HeatMap/Overview.md
+++ b/wpf/HeatMap/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Overview of WPF HeatMap (SfHeatMap) Control | Syncfusion
-description: Learn here all about overview of Syncfusion Essential Studio WPF HeatMap (SfHeatMap) control, its elements, and more.
+description: Learn here all about overview of Syncfusion Essential Studio® WPF HeatMap (SfHeatMap) control, its elements, and more.
 platform: wpf
 control: SfHeatMap
 documentation: ug


### PR DESCRIPTION
## Description ##
Replaced word "Essential Studio" with "Essential Studio®" in Diagram and Heatmap