### PR TITLE
Whether_need_to_unload_externally_before_loading_new_document

### DIFF
--- a/wpf-toc.html
+++ b/wpf-toc.html
@@ -1548,6 +1548,7 @@
 					<li><a href="/wpf/Pdf-Viewer/acquiring-current-page-being-displayed">Acquire current page being displayed</a></li>
 					<li><a href="/wpf/Pdf-Viewer/enabling-and-disabling-notification-bar">Enable and Disable Notification bar</a></li>
 					<li><a href="/wpf/Pdf-Viewer/how-to/Disable-the-Undo-Redo-operation">Disable the Undo Redo operation</a></li>
+					<li><a href="/wpf/Pdf-Viewer/how-to/Unload-the-document">Unload the document</a></li>
                 </ul>
             </li>
         </ul>

--- a/wpf/Pdf-Viewer/How-To/Unload-the-document.md
+++ b/wpf/Pdf-Viewer/How-To/Unload-the-document.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title: Unload the document in WPF Pdf Viewer | Syncfusion®
+description: Learn how the Syncfusion® WPF PDF Viewer control automatically unloads the current document when loading a new one, eliminating the need for manual unloading.
+platform: wpf
+control: PDF Viewer
+documentation: ug
+---
+
+# Unload the document in Pdf Viewer
+
+The WPF PDF Viewer also allows a user to Unload the PDF document using [Unload()](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.PdfViewer.PdfViewerControl.html#Syncfusion_Windows_PdfViewer_PdfViewerControl_Unload) API of the [PdfViewerControl](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.PdfViewer.PdfViewerControl.html) and [PdfDocumentView](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.PdfViewer.PdfDocumentView.html) classes.
+A user can dispose the PDF document by passing the Boolean parameter as ‘true’ to the [Unload(Boolean)](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.PdfViewer.PdfViewerControl.html#Syncfusion_Windows_PdfViewer_PdfViewerControl_Unload_System_Boolean_) API. The below code illustrates how to dispose the PDF document programmatically.
+
+{% tabs %}
+{% highlight c# %}
+
+private void UnloadButton_Click(object sender, RoutedEventArgs e)
+{
+      //Unload the PDF document
+      pdfviewer.Unload(true);
+}
+
+{% endhighlight %}
+{% highlight VB %}
+
+Private Sub UnloadButton_Click(sender As Object, e As RoutedEventArgs)
+     'Unload the PDF document
+    pdfviewer.Unload(true)
+End Sub
+
+{% endhighlight %}
+{% endtabs %}
+
+N>In PdfViewerControl, it is recommended not to unload the PDF document externally when loading a new PDF document, as the control internally handles the unloading process.
+


### PR DESCRIPTION
Refer:[871183-Whether need to unload externally, before loading new document by Yaminisrisf4389 · Pull Request #1558 · syncfusion-content/wpf-docs](https://github.com/syncfusion-content/wpf-docs/pull/1558)