### PR TITLE
UG-940787 Included the Registered Trademark Symbol in Tools WPF UG Document

### DIFF
--- a/wpf/Badge/Alignment-positioning.md
+++ b/wpf/Badge/Alignment-positioning.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Alignment and positioning in WPF Badge control | Syncfusion
-description: Learn here all about Alignment and positioning support in Syncfusion WPF Badge (SfBadge) control and more.
+title: Alignment and positioning in WPF Badge control | Syncfusion®
+description: Learn here all about Alignment and positioning support in Syncfusion® WPF Badge (SfBadge) control and more.
 platform: WPF
 control: SfBadge
 documentation: ug

--- a/wpf/Badge/Alignment-positioning.md
+++ b/wpf/Badge/Alignment-positioning.md
@@ -2,7 +2,7 @@
 layout: post
 title: Alignment and positioning in WPF Badge control | Syncfusion®
 description: Learn here all about Alignment and positioning support in Syncfusion® WPF Badge (SfBadge) control and more.
-platform: WPF
+platform: wpf
 control: SfBadge
 documentation: ug
 ---

--- a/wpf/Badge/Badge-Customization.md
+++ b/wpf/Badge/Badge-Customization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customization in WPF Badge control | Syncfusion
-description: Learn here all about Customization support in Syncfusion WPF Badge (SfBadge) control, its elements and more details.
+title: Customization in WPF Badge control | Syncfusion®
+description: Learn here all about Customization support in Syncfusion® WPF Badge (SfBadge) control, its elements and more details.
 platform: WPF
 control: SfBadge
 documentation: ug

--- a/wpf/Badge/Badge-Customization.md
+++ b/wpf/Badge/Badge-Customization.md
@@ -2,7 +2,7 @@
 layout: post
 title: Customization in WPF Badge control | Syncfusion®
 description: Learn here all about Customization support in Syncfusion® WPF Badge (SfBadge) control, its elements and more details.
-platform: WPF
+platform: wpf
 control: SfBadge
 documentation: ug
 ---

--- a/wpf/Badge/Getting-Started.md
+++ b/wpf/Badge/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Badge control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Badge (SfBadge) control, its elements and more details.
+title: Getting Started with WPF Badge control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Badge (SfBadge) control, its elements and more details.
 platform: WPF
 control: SfBadge
 documentation: ug
@@ -32,7 +32,7 @@ To add the `SfBadge` manually in XAML, follow these steps:
     * Syncfusion.Shared.WPF
     * Syncfusion.Tools.WPF
 
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf**, and declare the `SfBadge` in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf**, and declare the `SfBadge` in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Badge/Getting-Started.md
+++ b/wpf/Badge/Getting-Started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting Started with WPF Badge control | Syncfusion®
 description: Learn here about getting started with Syncfusion® WPF Badge (SfBadge) control, its elements and more details.
-platform: WPF
+platform: wpf
 control: SfBadge
 documentation: ug
 ---

--- a/wpf/Badge/Overview.md
+++ b/wpf/Badge/Overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About WPF Badge control | Syncfusion®
 description: Learn here all about introduction of Syncfusion® WPF Badge (SfBadge) control, its elements and more details.
-platform: WPF
+platform: wpf
 control: SfBadge
 documentation: ug
 ---

--- a/wpf/Badge/Overview.md
+++ b/wpf/Badge/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About WPF Badge control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Badge (SfBadge) control, its elements and more details.
+title: About WPF Badge control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Badge (SfBadge) control, its elements and more details.
 platform: WPF
 control: SfBadge
 documentation: ug

--- a/wpf/Calculator/Getting-Started.md
+++ b/wpf/Calculator/Getting-Started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting Started with WPF Calculator control | Syncfusion®
 description: Learn here about getting started with Syncfusion® WPF Calculator (SfCalculator) control, its elements and more.
-platform: WPF
+platform: wpf
 control: SfCalculator
 documentation: ug
 ---

--- a/wpf/Calculator/Getting-Started.md
+++ b/wpf/Calculator/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Calculator control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Calculator (SfCalculator) control, its elements and more.
+title: Getting Started with WPF Calculator control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Calculator (SfCalculator) control, its elements and more.
 platform: WPF
 control: SfCalculator
 documentation: ug
@@ -41,7 +41,7 @@ In order to add [SfCalculator](https://help.syncfusion.com/cr/wpf/Syncfusion.Win
    * Syncfusion.SfInput.WPF
    * Syncfusion.Shared.WPF
 
-2. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** in XAML page.
+2. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** in XAML page.
 
 3. Declare [SfCalculator](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfCalculator.html) in XAML page.
 

--- a/wpf/Calculator/Memory.md
+++ b/wpf/Calculator/Memory.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Memory in WPF Calculator control | Syncfusion
-description: Learn here all about Memory support in Syncfusion WPF Calculator (SfCalculator) control, its elements and more details.
-platform: wpf
+title: Memory in WPF Calculator control | Syncfusion®
+description: Learn here all about Memory support in Syncfusion® WPF Calculator (SfCalculator) control, its elements and more details.
+platform: WPF
 control: SfCalculator
 documentation: ug
 ---

--- a/wpf/Calculator/Memory.md
+++ b/wpf/Calculator/Memory.md
@@ -2,7 +2,7 @@
 layout: post
 title: Memory in WPF Calculator control | Syncfusion®
 description: Learn here all about Memory support in Syncfusion® WPF Calculator (SfCalculator) control, its elements and more details.
-platform: WPF
+platform: wpf
 control: SfCalculator
 documentation: ug
 ---

--- a/wpf/Calculator/Overview.md
+++ b/wpf/Calculator/Overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About WPF Calculator control | Syncfusion®
 description: Learn here all about introduction of Syncfusion® WPF Calculator (SfCalculator) control, its elements and more details.
-platform: WPF
+platform: wpf
 control: SfCalculator
 documentation: ug
 ---

--- a/wpf/Calculator/Overview.md
+++ b/wpf/Calculator/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Calculator control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Calculator (SfCalculator) control, its elements and more details.
-platform: wpf
+title: About WPF Calculator control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Calculator (SfCalculator) control, its elements and more details.
+platform: WPF
 control: SfCalculator
 documentation: ug
 ---

--- a/wpf/Calendar/Appearance.md
+++ b/wpf/Calendar/Appearance.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance in WPF Calendar control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF Calendar (CalendarEdit) control, its elements and more details.
+title: Appearance in WPF Calendar control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF Calendar (CalendarEdit) control, its elements and more details.
 platform: wpf
 control: CalendarEdit
 documentation: ug

--- a/wpf/Calendar/Date-Selection.md
+++ b/wpf/Calendar/Date-Selection.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Date-Selection in WPF Calendar control | Syncfusion
-description: Learn here all about Date-Selection support in Syncfusion WPF Calendar (CalendarEdit) control and more.
+title: Date-Selection in WPF Calendar control | Syncfusion®
+description: Learn here all about Date-Selection support in Syncfusion® WPF Calendar (CalendarEdit) control and more.
 platform: wpf
 control: CalendarEdit
 documentation: ug

--- a/wpf/Calendar/Getting-Started.md
+++ b/wpf/Calendar/Getting-Started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting Started with WPF Calendar control | Syncfusion®
 description: Learn here about getting started with Syncfusion® WPF Calendar (CalendarEdit) control, its elements and more.
-platform: WPF
+platform: wpf
 control: CalendarEdit
 documentation: ug
 ---

--- a/wpf/Calendar/Getting-Started.md
+++ b/wpf/Calendar/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Calendar control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Calendar (CalendarEdit) control, its elements and more.
+title: Getting Started with WPF Calendar control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Calendar (CalendarEdit) control, its elements and more.
 platform: WPF
 control: CalendarEdit
 documentation: ug
@@ -43,7 +43,7 @@ To add the `CalendarEdit` manually in XAML, follow these steps:
 
     * Syncfusion.Shared.WPF
 
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf**, and declare the CalendarEdit in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf**, and declare the CalendarEdit in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Calendar/Navigation-Support.md
+++ b/wpf/Calendar/Navigation-Support.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Date Navigation in WPF Calendar control | Syncfusion
-description: Learn here all about Date Navigation support in Syncfusion WPF Calendar (CalendarEdit) control and more.
+title: Date Navigation in WPF Calendar control | Syncfusion®
+description: Learn here all about Date Navigation support in Syncfusion® WPF Calendar (CalendarEdit) control and more.
 platform: WPF
 control: CalendarEdit
 documentation: ug

--- a/wpf/Calendar/Navigation-Support.md
+++ b/wpf/Calendar/Navigation-Support.md
@@ -2,7 +2,7 @@
 layout: post
 title: Date Navigation in WPF Calendar control | Syncfusion®
 description: Learn here all about Date Navigation support in Syncfusion® WPF Calendar (CalendarEdit) control and more.
-platform: WPF
+platform: wpf
 control: CalendarEdit
 documentation: ug
 ---

--- a/wpf/Calendar/Overview.md
+++ b/wpf/Calendar/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About WPF Calendar control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Calendar (CalendarEdit) control, its elements and more details.
+title: About WPF Calendar control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Calendar (CalendarEdit) control, its elements and more details.
 platform: wpf
 control: CalendarEdit
 documentation: ug

--- a/wpf/Calendar/Restrict-Date-Selection.md
+++ b/wpf/Calendar/Restrict-Date-Selection.md
@@ -2,7 +2,7 @@
 layout: post
 title: Restrict Date Selection in WPF Calendar control | Syncfusion®
 description: Learn here all about Restrict Date Selection support in Syncfusion® WPF Calendar (CalendarEdit) control and more.
-platform: WPF
+platform: wpf
 control: CalendarEdit
 documentation: ug
 ---

--- a/wpf/Calendar/Restrict-Date-Selection.md
+++ b/wpf/Calendar/Restrict-Date-Selection.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Restrict Date Selection in WPF Calendar control | Syncfusion
-description: Learn here all about Restrict Date Selection support in Syncfusion WPF Calendar (CalendarEdit) control and more.
+title: Restrict Date Selection in WPF Calendar control | Syncfusion®
+description: Learn here all about Restrict Date Selection support in Syncfusion® WPF Calendar (CalendarEdit) control and more.
 platform: WPF
 control: CalendarEdit
 documentation: ug

--- a/wpf/Calendar/Using-CalendarEdit-Object.md
+++ b/wpf/Calendar/Using-CalendarEdit-Object.md
@@ -2,7 +2,7 @@
 layout: post
 title: Using CalendarEdit Object in WPF Calendar control | Syncfusion®
 description: Learn here all about Using CalendarEdit Object support in Syncfusion® WPF Calendar (CalendarEdit) control and more.
-platform: WPF
+platform: wpf
 control: CalendarEdit
 documentation: ug
 ---

--- a/wpf/Calendar/Using-CalendarEdit-Object.md
+++ b/wpf/Calendar/Using-CalendarEdit-Object.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Using CalendarEdit Object in WPF Calendar control | Syncfusion
-description: Learn here all about Using CalendarEdit Object support in Syncfusion WPF Calendar (CalendarEdit) control and more.
-platform: wpf
+title: Using CalendarEdit Object in WPF Calendar control | Syncfusion®
+description: Learn here all about Using CalendarEdit Object support in Syncfusion® WPF Calendar (CalendarEdit) control and more.
+platform: WPF
 control: CalendarEdit
 documentation: ug
 ---

--- a/wpf/Carousel/Custom-Path.md
+++ b/wpf/Carousel/Custom-Path.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Custom Path in WPF carousel control | Syncfusion
-description: Learn here all about Custom Path support in Syncfusion WPF carousel (Carousel) control, its elements and more details.
-platform: wpf
+title: Custom Path in WPF carousel control | Syncfusion®
+description: Learn here all about Custom Path support in Syncfusion® WPF carousel (Carousel) control, its elements and more details.
+platform: WPF
 control: Carousel
 documentation: ug
 ---

--- a/wpf/Carousel/Custom-Path.md
+++ b/wpf/Carousel/Custom-Path.md
@@ -2,7 +2,7 @@
 layout: post
 title: Custom Path in WPF carousel control | Syncfusion®
 description: Learn here all about Custom Path support in Syncfusion® WPF carousel (Carousel) control, its elements and more details.
-platform: WPF
+platform: wpf
 control: Carousel
 documentation: ug
 ---

--- a/wpf/Carousel/Getting-Started.md
+++ b/wpf/Carousel/Getting-Started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting Started with WPF Carousel control | Syncfusion®
 description: Learn here about getting started with Syncfusion® Essential Studio® WPF Carousel control, its elements and more.
-platform: WPF
+platform: wpf
 control: Carousel
 documentation: ug
 ---

--- a/wpf/Carousel/Getting-Started.md
+++ b/wpf/Carousel/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Carousel control | Syncfusion
-description: Learn here about getting started with Syncfusion Essential Studio WPF Carousel control, its elements and more.
+title: Getting Started with WPF Carousel control | Syncfusion®
+description: Learn here about getting started with Syncfusion® Essential Studio® WPF Carousel control, its elements and more.
 platform: WPF
 control: Carousel
 documentation: ug
@@ -41,7 +41,7 @@ To add the `Carousel` manually in XAML, follow these steps:
 
     * Syncfusion.Shared.WPF
 
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf**, and declare the Carousel in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf**, and declare the Carousel in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Carousel/How-To/Change-SelectedItem-Position.md
+++ b/wpf/Carousel/How-To/Change-SelectedItem-Position.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Change SelectedItem position in WPF Carousel control | Syncfusion
-description: Change SelectedItem position of the Syncfusion Essential Studio WPF Carousel control, its elements and more.
+title: Change SelectedItem position in WPF Carousel control | Syncfusion®
+description: Change SelectedItem position of the Syncfusion® Essential Studio WPF Carousel control, its elements and more.
 platform: wpf
 control: Carousel
 documentation: ug

--- a/wpf/Carousel/Items-Navigation.md
+++ b/wpf/Carousel/Items-Navigation.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Items Navigation in WPF Carousel control | Syncfusion
-description: Learn about Items Navigation support in Syncfusion Essential Studio WPF Carousel control, its elements and more details.
-platform: wpf
+title: Items Navigation in WPF Carousel control | Syncfusion®
+description: Learn about Items Navigation support in Syncfusion® Essential Studio® WPF Carousel control, its elements and more details.
+platform: WPF
 control: Carousel 
 documentation: ug
 ---

--- a/wpf/Carousel/Items-Navigation.md
+++ b/wpf/Carousel/Items-Navigation.md
@@ -2,7 +2,7 @@
 layout: post
 title: Items Navigation in WPF Carousel control | Syncfusion®
 description: Learn about Items Navigation support in Syncfusion® Essential Studio® WPF Carousel control, its elements and more details.
-platform: WPF
+platform: wpf
 control: Carousel 
 documentation: ug
 ---

--- a/wpf/Carousel/Overview.md
+++ b/wpf/Carousel/Overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About WPF Carousel control | Syncfusion®
 description: Learn here all about introduction of Syncfusion® WPF Carousel control, its elements and more details.
-platform: WPF
+platform: wpf
 control: Carousel
 documentation: ug
 ---

--- a/wpf/Carousel/Overview.md
+++ b/wpf/Carousel/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Carousel control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Carousel control, its elements and more details.
-platform: wpf
+title: About WPF Carousel control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Carousel control, its elements and more details.
+platform: WPF
 control: Carousel
 documentation: ug
 ---

--- a/wpf/Carousel/Populating-Items.md
+++ b/wpf/Carousel/Populating-Items.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Populating Items in WPF Carousel control | Syncfusion
-description: Learn about Populating Items support in Syncfusion Essential Studio WPF Carousel control, its elements and more details.
+title: Populating Items in WPF Carousel control | Syncfusion®
+description: Learn about Populating Items support in Syncfusion® Essential Studio® WPF Carousel control, its elements and more details.
 platform: WPF
 control: Carousel
 documentation: ug

--- a/wpf/Carousel/Populating-Items.md
+++ b/wpf/Carousel/Populating-Items.md
@@ -2,7 +2,7 @@
 layout: post
 title: Populating Items in WPF Carousel control | Syncfusion®
 description: Learn about Populating Items support in Syncfusion® Essential Studio® WPF Carousel control, its elements and more details.
-platform: WPF
+platform: wpf
 control: Carousel
 documentation: ug
 ---

--- a/wpf/Carousel/Standard-Path.md
+++ b/wpf/Carousel/Standard-Path.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Standard Path in WPF Carousel control | Syncfusion
-description: Learn about Standard Path support in Syncfusion Essential Studio WPF Carousel control, its elements and more details.
+title: Standard Path in WPF Carousel control | Syncfusion®
+description: Learn about Standard Path support in Syncfusion® Essential Studio® WPF Carousel control, its elements and more details.
 platform: wpf
 control: Carousel
 documentation: ug

--- a/wpf/CheckedListBox/How-to/check-the-item-in-checklistbox-when-initiating.md
+++ b/wpf/CheckedListBox/How-to/check-the-item-in-checklistbox-when-initiating.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Check item On initialization | CheckListBox | wpf | Syncfusion
+title: Check item On initialization | CheckListBox | wpf | Syncfusion®
 description: This section describes about how to check an item using SelectedItems in CheckListBox when initiating 
-platform: wpf
+platform: WPF
 control: CheckListBox
 documentation: ug
 ---

--- a/wpf/CheckedListBox/How-to/check-the-item-in-checklistbox-when-initiating.md
+++ b/wpf/CheckedListBox/How-to/check-the-item-in-checklistbox-when-initiating.md
@@ -2,7 +2,7 @@
 layout: post
 title: Check item On initialization | CheckListBox | wpf | Syncfusion®
 description: This section describes about how to check an item using SelectedItems in CheckListBox when initiating 
-platform: WPF
+platform: wpf
 control: CheckListBox
 documentation: ug
 ---

--- a/wpf/Color-Palette/Appearance.md
+++ b/wpf/Color-Palette/Appearance.md
@@ -2,7 +2,7 @@
 layout: post
 title: Appearance in WPF Color Palette control | Syncfusion®
 description: Learn here all about Appearance support in Syncfusion® WPF Color Palette (SfColorPalette) control and more.
-platform: WPF
+platform: wpf
 control: SfColorPalette
 documentation: ug
 ---

--- a/wpf/Color-Palette/Appearance.md
+++ b/wpf/Color-Palette/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF Color Palette control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF Color Palette (SfColorPalette) control and more.
-platform: wpf
+title: Appearance in WPF Color Palette control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF Color Palette (SfColorPalette) control and more.
+platform: WPF
 control: SfColorPalette
 documentation: ug
 ---

--- a/wpf/Color-Palette/Getting-Started.md
+++ b/wpf/Color-Palette/Getting-Started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting Started with WPF Color Palette control | Syncfusion®
 description: Learn here about getting started with Syncfusion® WPF Color Palette (SfColorPalette) control, its elements and more.
-platform: WPF
+platform: wpf
 control: SfColorPalette
 documentation: ug
 ---

--- a/wpf/Color-Palette/Getting-Started.md
+++ b/wpf/Color-Palette/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF Color Palette control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Color Palette (SfColorPalette) control, its elements and more.
-platform: wpf
+title: Getting Started with WPF Color Palette control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Color Palette (SfColorPalette) control, its elements and more.
+platform: WPF
 control: SfColorPalette
 documentation: ug
 ---
@@ -50,7 +50,7 @@ In order to add [SfColorPalette](https://help.syncfusion.com/cr/wpf/Syncfusion.W
 
     * Syncfusion.SfShared.Wpf
 
-2. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** or SfColorPalette namespace [**Syncfusion.Windows.Controls.Media**](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Media.html) in XAML page.
+2. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** or SfColorPalette namespace [**Syncfusion.Windows.Controls.Media**](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Media.html) in XAML page.
 
 3. Declare [SfColorPalette](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Media.SfColorPalette.html) control in XAML page.
 

--- a/wpf/Color-Palette/Overview.md
+++ b/wpf/Color-Palette/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Color Palette control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Color Palette (SfColorPalette) control, its elements and more.
-platform: wpf
+title: About WPF Color Palette control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Color Palette (SfColorPalette) control, its elements and more.
+platform: WPF
 control: SfColorPalette
 documentation: ug
 ---

--- a/wpf/Color-Palette/Overview.md
+++ b/wpf/Color-Palette/Overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About WPF Color Palette control | Syncfusion®
 description: Learn here all about introduction of Syncfusion® WPF Color Palette (SfColorPalette) control, its elements and more.
-platform: WPF
+platform: wpf
 control: SfColorPalette
 documentation: ug
 ---

--- a/wpf/Color-Picker-Palette/Appearance.md
+++ b/wpf/Color-Picker-Palette/Appearance.md
@@ -2,7 +2,7 @@
 layout: post
 title: Appearance in WPF Color Picker Palette control | Syncfusion®
 description: Learn about Appearance support in Syncfusion® WPF Color Picker Palette control, its elements and more details.
-platform: WPF
+platform: wpf
 control: ColorPickerPalette
 documentation: ug
 ---

--- a/wpf/Color-Picker-Palette/Appearance.md
+++ b/wpf/Color-Picker-Palette/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF Color Picker Palette control | Syncfusion
-description: Learn about Appearance support in Syncfusion WPF Color Picker Palette control, its elements and more details.
-platform: wpf
+title: Appearance in WPF Color Picker Palette control | Syncfusion®
+description: Learn about Appearance support in Syncfusion® WPF Color Picker Palette control, its elements and more details.
+platform: WPF
 control: ColorPickerPalette
 documentation: ug
 ---

--- a/wpf/Color-Picker-Palette/Getting-Started.md
+++ b/wpf/Color-Picker-Palette/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Color Picker Palette | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Color Picker Palette control, its elements, and more.
+title: Getting Started with WPF Color Picker Palette | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Color Picker Palette control, its elements, and more.
 platform: WPF
 control: colorPickerPalette
 documentation: ug
@@ -52,7 +52,7 @@ To add the `ColorPickerPalette` control manually in XAML, follow these steps:
 2. Add the  following assembly references to the project,
    * Syncfusion.Shared.WPF
  
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** and declare the `ColorPickerPalette` control in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** and declare the `ColorPickerPalette` control in XAML page.
 
 4. Declare the `ColorPickerPalette` control in XAML page.
 

--- a/wpf/Color-Picker-Palette/Getting-Started.md
+++ b/wpf/Color-Picker-Palette/Getting-Started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting Started with WPF Color Picker Palette | Syncfusion®
 description: Learn here about getting started with Syncfusion® WPF Color Picker Palette control, its elements, and more.
-platform: WPF
+platform: wpf
 control: colorPickerPalette
 documentation: ug
 ---

--- a/wpf/Color-Picker-Palette/Overview.md
+++ b/wpf/Color-Picker-Palette/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Color Picker Palette control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Color Picker Palette control, its elements and more details.
-platform: wpf
+title: About WPF Color Picker Palette control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Color Picker Palette control, its elements and more details.
+platform: WPF
 control: ColorPickerPalette
 documentation: ug
 ---

--- a/wpf/Color-Picker-Palette/Overview.md
+++ b/wpf/Color-Picker-Palette/Overview.md
@@ -2,7 +2,7 @@
 layout: post
 title: About WPF Color Picker Palette control | Syncfusion®
 description: Learn here all about introduction of Syncfusion® WPF Color Picker Palette control, its elements and more details.
-platform: WPF
+platform: wpf
 control: ColorPickerPalette
 documentation: ug
 ---

--- a/wpf/Color-Picker-Palette/Working-with-ColorPickerPalette.md
+++ b/wpf/Color-Picker-Palette/Working-with-ColorPickerPalette.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Working with ColorPickerPalette in WPF | Syncfusion
-description: Learn about Working with ColorPickerPalette support in Syncfusion WPF Color Picker Palette control and more.
-platform: wpf
+title: Working with ColorPickerPalette in WPF | Syncfusion®
+description: Learn about Working with ColorPickerPalette support in Syncfusion® WPF Color Picker Palette control and more.
+platform: WPF
 control: ColorPickerPalette
 documentation: ug
 ---

--- a/wpf/Color-Picker-Palette/Working-with-ColorPickerPalette.md
+++ b/wpf/Color-Picker-Palette/Working-with-ColorPickerPalette.md
@@ -2,7 +2,7 @@
 layout: post
 title: Working with ColorPickerPalette in WPF | Syncfusion®
 description: Learn about Working with ColorPickerPalette support in Syncfusion® WPF Color Picker Palette control and more.
-platform: WPF
+platform: wpf
 control: ColorPickerPalette
 documentation: ug
 ---

--- a/wpf/Color-Picker-Palette/Working-with-ColorPickerPalette.md
+++ b/wpf/Color-Picker-Palette/Working-with-ColorPickerPalette.md
@@ -375,7 +375,7 @@ colorPickerPalette.NoColorVisibility = Visibility.Visible;
 {% endhighlight %}
 {% endtabs %}
 
-![ColorPickerPalette reset selected color as Transparent by clicking the No color button](Dealing-with-ColorPickerPalette_images/NoColor.png)
+![ColorPickerPalette reset selected color as Transparent by clicking the No color button](Dealing-with-ColorPickerPalette_images/wpf-reset-transparency-button.png)
 
 N> [View Sample  in GitHub](https://github.com/SyncfusionExamples/syncfusion-color-picker-palette-wpf-examples/tree/master/Samples/Getting-Started)
 

--- a/wpf/Color-Picker/Appearance.md
+++ b/wpf/Color-Picker/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF color picker control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF color picker (ColorPicker) control and more.
-platform: wpf
+title: Appearance in WPF color picker control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF color picker (ColorPicker) control and more.
+platform: WPF
 control: ColorPicker
 documentation: ug
 ---

--- a/wpf/Color-Picker/Appearance.md
+++ b/wpf/Color-Picker/Appearance.md
@@ -2,7 +2,7 @@
 layout: post
 title: Appearance in WPF color picker control | Syncfusion®
 description: Learn here all about Appearance support in Syncfusion® WPF color picker (ColorPicker) control and more.
-platform: WPF
+platform: wpf
 control: ColorPicker
 documentation: ug
 ---

--- a/wpf/Color-Picker/Choose-a-color.md
+++ b/wpf/Color-Picker/Choose-a-color.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Select solid color in WPF color picker control | Syncfusion
-description: Learn here all about Select solid color support in Syncfusion WPF color picker (ColorPicker) control and more.
-platform: wpf
+title: Select solid color in WPF color picker control | Syncfusion®
+description: Learn here all about Select solid color support in Syncfusion® WPF color picker (ColorPicker) control and more.
+platform: WPF
 control: ColorPicker
 documentation: ug
 ---

--- a/wpf/Color-Picker/Customization.md
+++ b/wpf/Color-Picker/Customization.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Customization | ColorPicker | wpf | Syncfusion
+title: Customization | ColorPicker | wpf | Syncfusion®
 description: This section explains about layout related properties such as FlowDirection, ColorPalette enabled and display mode etc.
 platform: wpf
 control: ColorPicker

--- a/wpf/Color-Picker/Getting-Started.md
+++ b/wpf/Color-Picker/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF color picker control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF color picker (ColorPicker) control, its elements and more.
-platform: wpf
+title: Getting Started with WPF color picker control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF color picker (ColorPicker) control, its elements and more.
+platform: WPF
 control: ColorPicker
 documentation: ug
 ---
@@ -39,7 +39,7 @@ To add the `ColorPicker` manually in XAML, follow these steps:
 
     * Syncfusion.Shared.WPF
 
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf**, and declare the `ColorPicker` in WPF XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf**, and declare the `ColorPicker` in WPF XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Color-Picker/Gradient-Brush.md
+++ b/wpf/Color-Picker/Gradient-Brush.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Select gradient color in WPF color picker control | Syncfusion
-description: Learn here all about Select gradient color support in Syncfusion WPF color picker (ColorPicker) control and more.
-platform: wpf
+title: Select gradient color in WPF color picker control | Syncfusion®
+description: Learn here all about Select gradient color support in Syncfusion® WPF color picker (ColorPicker) control and more.
+platform: WPF
 control: ColorPicker
 documentation: ug
 ---

--- a/wpf/Color-Picker/Overview.md
+++ b/wpf/Color-Picker/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF color picker control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF color picker (ColorPicker) control, its elements and more.
-platform: wpf
+title: About WPF color picker control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF color picker (ColorPicker) control, its elements and more.
+platform: WPF
 control: ColorPicker
 documentation: ug
 ---

--- a/wpf/Currency-TextBox/Appearance.md
+++ b/wpf/Currency-TextBox/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF Currency TextBox control | Syncfusion
-description: Learn about Appearance support in Syncfusion WPF Currency TextBox control, its elements and more details.
-platform: wpf
+title: Appearance in WPF Currency TextBox control | Syncfusion®
+description: Learn about Appearance support in Syncfusion® WPF Currency TextBox control, its elements and more details.
+platform: WPF
 control: CurrencyTextBox
 documentation: ug
 ---

--- a/wpf/Currency-TextBox/Changing-Currency-Value.md
+++ b/wpf/Currency-TextBox/Changing-Currency-Value.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Changing Currency Value in WPF Currency TextBox control | Syncfusion
-description: Learn about Changing Currency Value support in Syncfusion WPF Currency TextBox control, its elements and more details.
-platform: wpf
+title: Changing Currency Value in WPF Currency TextBox control | Syncfusion®
+description: Learn about Changing Currency Value support in Syncfusion® WPF Currency TextBox control, its elements and more details.
+platform: WPF
 control: CurrencyTextBox 
 documentation: ug
 ---

--- a/wpf/Currency-TextBox/Culture-and-Number-Formats.md
+++ b/wpf/Currency-TextBox/Culture-and-Number-Formats.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Culture and Formatting in WPF Currency TextBox control | Syncfusion
-description: Learn about Culture and Formatting support in Syncfusion WPF Currency TextBox control, its elements and more details.
-platform: wpf
+title: Culture and Formatting in WPF Currency TextBox control | Syncfusion®
+description: Learn about Culture and Formatting support in Syncfusion® WPF Currency TextBox control, its elements and more details.
+platform: WPF
 control: CurrencyTextBox
 documentation: ug
 ---

--- a/wpf/Currency-TextBox/Getting-Started.md
+++ b/wpf/Currency-TextBox/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Currency TextBox control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Currency TextBox control, its elements and more.
+title: Getting Started with WPF Currency TextBox control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Currency TextBox control, its elements and more.
 platform: WPF
 control: CurrencyTextBox
 documentation: ug
@@ -34,7 +34,7 @@ To add the CurrencyTextBox control manually in XAML, follow these steps:
 
 2. Add the **Syncfusion.Shared.WPF** assembly references to the project.
  
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** and declare the `CurrencyTextBox` control in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** and declare the `CurrencyTextBox` control in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Currency-TextBox/Overview.md
+++ b/wpf/Currency-TextBox/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Currency TextBox control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Currency TextBox control, its elements and more.
-platform: wpf
+title: About WPF Currency TextBox control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Currency TextBox control, its elements and more.
+platform: WPF
 control: CurrencyTextBox
 documentation: ug
 ---

--- a/wpf/Currency-TextBox/Range-Adorner.md
+++ b/wpf/Currency-TextBox/Range-Adorner.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Range Adorner in WPF Currency TextBox control | Syncfusion
-description: Learn about Range Adorner support in Syncfusion WPF Currency TextBox control, its elements and more details.
-platform: wpf
+title: Range Adorner in WPF Currency TextBox control | Syncfusion®
+description: Learn about Range Adorner support in Syncfusion® WPF Currency TextBox control, its elements and more details.
+platform: WPF
 control: CurrencyTextBox 
 documentation: ug
 ---

--- a/wpf/Currency-TextBox/Restriction-or-Validation.md
+++ b/wpf/Currency-TextBox/Restriction-or-Validation.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Restriction or Validation in WPF Currency TextBox control | Syncfusion
-description: Learn about Restriction or Validation support in Syncfusion WPF Currency TextBox control, its elements and more details.
-platform: wpf
+title: Restriction or Validation in WPF Currency TextBox control | Syncfusion®
+description: Learn about Restriction or Validation support in Syncfusion® WPF Currency TextBox control, its elements and more details.
+platform: WPF
 control: CurrencyTextBox 
 documentation: ug
 ---

--- a/wpf/Currency-TextBox/Step-Interval.md
+++ b/wpf/Currency-TextBox/Step-Interval.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Step Interval in WPF Currency TextBox control | Syncfusion
-description: Learn about Step Interval support in Syncfusion WPF Currency TextBox control, its elements and more details.
-platform: wpf
+title: Step Interval in WPF Currency TextBox control | Syncfusion®
+description: Learn about Step Interval support in Syncfusion® WPF Currency TextBox control, its elements and more details.
+platform: WPF
 control: CurrencyTextBox 
 documentation: ug
 ---

--- a/wpf/DatePicker/Appearance-and-Styling.md
+++ b/wpf/DatePicker/Appearance-and-Styling.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF DatePicker control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF DatePicker (SfDatePicker) control and more.
-platform: wpf
+title: Appearance in WPF DatePicker control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF DatePicker (SfDatePicker) control and more.
+platform: WPF
 control: SfDatePicker
 documentation: ug
 ---

--- a/wpf/DatePicker/Customizing-DropDown.md
+++ b/wpf/DatePicker/Customizing-DropDown.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Customizing DropDown in WPF DatePicker control | Syncfusion
-description: Learn here all about Customizing DropDown support in Syncfusion WPF DatePicker (SfDatePicker) control and more.
-platform: wpf
+title: Customizing DropDown in WPF DatePicker control | Syncfusion®
+description: Learn here all about Customizing DropDown support in Syncfusion® WPF DatePicker (SfDatePicker) control and more.
+platform: WPF
 control:  SfDatePicker
 documentation: ug
 ---

--- a/wpf/DatePicker/Formatting.md
+++ b/wpf/DatePicker/Formatting.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Date Formatting in WPF DatePicker control | Syncfusion
-description: Learn here all about Date Formatting support in Syncfusion WPF DatePicker (SfDatePicker) control and more.
-platform: wpf
+title: Date Formatting in WPF DatePicker control | Syncfusion®
+description: Learn here all about Date Formatting support in Syncfusion® WPF DatePicker (SfDatePicker) control and more.
+platform: WPF
 control: SfDatePicker
 documentation: ug
 ---

--- a/wpf/DatePicker/Getting-Started.md
+++ b/wpf/DatePicker/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF DatePicker control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF DatePicker (SfDatePicker) control, its elements and more.
+title: Getting Started with WPF DatePicker control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF DatePicker (SfDatePicker) control, its elements and more.
 platform: WPF
 control: SfDatePicker
 documentation: ug
@@ -39,7 +39,7 @@ To add the control manually in XAML, follow the given steps:
 1. Add the following required assembly references to the project:
     * Syncfusion.SfInput.WPF
     * Syncfusion.SfShared.WPF
-2. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
+2. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
 3. Declare the `SfDatePicker` control in the XAML page.
 
 {% capture codesnippet1 %}

--- a/wpf/DatePicker/Overview.md
+++ b/wpf/DatePicker/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF DatePicker control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF DatePicker (SfDatePicker) control, its elements and more.
-platform: wpf
+title: About WPF DatePicker control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF DatePicker (SfDatePicker) control, its elements and more.
+platform: WPF
 control: SfDatePicker
 documentation: ug
 ---

--- a/wpf/DatePicker/Setting-Value.md
+++ b/wpf/DatePicker/Setting-Value.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Setting Date in WPF DatePicker control | Syncfusion
-description: Learn here all about Setting Date support in Syncfusion WPF DatePicker (SfDatePicker) control and more.
-platform: wpf
+title: Setting Date in WPF DatePicker control | Syncfusion®
+description: Learn here all about Setting Date support in Syncfusion® WPF DatePicker (SfDatePicker) control and more.
+platform: WPF
 control: SfDatePicker
 documentation: ug
 ---

--- a/wpf/DatePicker/SfDateSelector.md
+++ b/wpf/DatePicker/SfDateSelector.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Date Selector in WPF DatePicker control | Syncfusion
-description: Learn here all about Date Selector support in Syncfusion WPF DatePicker (SfDatePicker) control and more.
-platform: wpf
+title: Date Selector in WPF DatePicker control | Syncfusion®
+description: Learn here all about Date Selector support in Syncfusion® WPF DatePicker (SfDatePicker) control and more.
+platform: WPF
 control: SfDatePicker
 documentation: ug
 ---

--- a/wpf/Docking/Advanced-Features.md
+++ b/wpf/Docking/Advanced-Features.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Advanced Features | DockingManager | WPF | Syncfusion
-description: Advanced features of Syncfusion Essential Studio WPF DockingManager Control, its elements, features and more.
-platform: wpf
+title: Advanced Features | DockingManager | WPF | Syncfusion®
+description: Advanced features of Syncfusion® Essential Studio® WPF DockingManager Control, its elements, features and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Auto-Hide-Window.md
+++ b/wpf/Docking/Auto-Hide-Window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Auto Hide Window in WPF Docking control | Syncfusion
-description: Learn here all about Auto Hide Window support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Auto Hide Window in WPF Docking control | Syncfusion®
+description: Learn here all about Auto Hide Window support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Basic-Features.md
+++ b/wpf/Docking/Basic-Features.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Basic Features | DockingManager | WPF | Syncfusion
-description: Basic features of Syncfusion Essential Studio WPF DockingManager Control, its elements, features and more.
-platform: wpf
+title: Basic Features | DockingManager | WPF | Syncfusion®
+description: Basic features of Syncfusion® Essential Studio® WPF DockingManager Control, its elements, features and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Data-Binding.md
+++ b/wpf/Docking/Data-Binding.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Data Binding in WPF Docking control | Syncfusion
-description: Learn here all about Data Binding support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Data Binding in WPF Docking control | Syncfusion®
+description: Learn here all about Data Binding support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Dealing-with-Windows.md
+++ b/wpf/Docking/Dealing-with-Windows.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Dealing with Windows in WPF Docking control | Syncfusion
-description: Learn here all about Dealing with Windows support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Dealing with Windows in WPF Docking control | Syncfusion®
+description: Learn here all about Dealing with Windows support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Dock-Hints.md
+++ b/wpf/Docking/Dock-Hints.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Interaction with DragProvider in WPF Docking control | Syncfusion
-description: Learn here all about Interaction with DragProvider support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Interaction with DragProvider in WPF Docking control | Syncfusion®
+description: Learn here all about Interaction with DragProvider support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Docking-Window.md
+++ b/wpf/Docking/Docking-Window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Docking Window in WPF Docking control | Syncfusion
-description: Learn here all about Docking Window support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Docking Window in WPF Docking control | Syncfusion®
+description: Learn here all about Docking Window support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Floating-Window.md
+++ b/wpf/Docking/Floating-Window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Floating Window in WPF Docking control | Syncfusion
-description: Learn here all about Floating Window support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Floating Window in WPF Docking control | Syncfusion®
+description: Learn here all about Floating Window support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Getting-Started.md
+++ b/wpf/Docking/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF Docking control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Docking (DockingManager) control, its elements and more details.
-platform: wpf
+title: Getting Started with WPF Docking control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Docking (DockingManager) control, its elements and more details.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Hosting-Windows-Form-control-as-a-window.md
+++ b/wpf/Docking/Hosting-Windows-Form-control-as-a-window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Hosting in WPF DockingManager control | Syncfusion
-description: Learn here all about Hosting Windows Form control as a Window support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Hosting in WPF DockingManager control | Syncfusion®
+description: Learn here all about Hosting Windows Form control as a Window support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Activate-a-particular-window.md
+++ b/wpf/Docking/How-to/Activate-a-particular-window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Activate a particular window | DockingManager | wpf | Syncfusion
-description: Activate a particular window in Syncfusion Essential Studio WPF DockingManager Control, its elements and more.
-platform: wpf
+title: Activate a particular window | DockingManager | wpf | Syncfusion®
+description: Activate a particular window in Syncfusion® Essential Studio® WPF DockingManager Control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/AutoHide-all-docked-windows.md
+++ b/wpf/Docking/How-to/AutoHide-all-docked-windows.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: AutoHide all docked windows | DockingManager | wpf | Syncfusion
-description: Autohide all docked windows in Syncfusion Essential Studio WPF DockingManager Control, its elements and more.
-platform: wpf
+title: AutoHide all docked windows | DockingManager | wpf | Syncfusion®
+description: Autohide all docked windows in Syncfusion® Essential Studio® WPF DockingManager Control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Cancel-the-ActiveWindow-Change.md
+++ b/wpf/Docking/How-to/Cancel-the-ActiveWindow-Change.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Cancel the ActiveWindow Change | DockingManager | wpf | Syncfusion
-description: Cancel the activewindow change in Syncfusion Essential Studio WPF DockingManager Control, its elements and more.
-platform: wpf
+title: Cancel the ActiveWindow Change | DockingManager | wpf | Syncfusion®
+description: Cancel the activewindow change in Syncfusion® Essential Studio® WPF DockingManager Control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Clear-StatePersistance-Entries.md
+++ b/wpf/Docking/How-to/Clear-StatePersistance-Entries.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Clear StatePersistance Entries | DockingManager | wpf | Syncfusion
-description:  Clear statepersistance entries in Syncfusion Essential Studio WPF DockingManager Control, its elements and more.
-platform: wpf
+title: Clear StatePersistance Entries | DockingManager | wpf | Syncfusion®
+description:  Clear statepersistance entries in Syncfusion® Essential Studio® WPF DockingManager Control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Configuring-a-build-machine-to-compile-projects-after-version-V81030.md
+++ b/wpf/Docking/How-to/Configuring-a-build-machine-to-compile-projects-after-version-V81030.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: Configuring a build machine in WPF DockingManager Control | Syncfusion
-description: Configuring a build machine to compile projects after version v8.1.0.30 in Syncfusion WPF DockingManager control, its elements and more.
-platform: wpf
+title: Configuring a build machine in WPF DockingManager Control | Syncfusion®
+description: Configuring a build machine to compile projects after version v8.1.0.30 in Syncfusion® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---
 
 # Configuring a build machine in WPF DockingManager Control
 
-To compile projects that use Syncfusion controls in a build machine, Syncfusion helps to install the Link Install Setup. The setup installs Syncfusion assemblies into the target folder, and registers the product key to the registry. This allows you to compile a project, developed on a build machine. Please download the link install setup from the below location 
+To compile projects that use Syncfusion<sup>®</sup> controls in a build machine, Syncfusion<sup>®</sup> helps to install the Link Install Setup. The setup installs Syncfusion<sup>®</sup> assemblies into the target folder, and registers the product key to the registry. This allows you to compile a project, developed on a build machine. Please download the link install setup from the below location 
 
 [http://files2.syncfusion.com/installs/v9.1.0.20/essentialstudiolinkinstall.exe](http://files2.syncfusion.com/installs/v9.1.0.20/essentialstudiolinkinstall.exe)
 

--- a/wpf/Docking/How-to/Configuring-a-build-machine-to-compile.md
+++ b/wpf/Docking/How-to/Configuring-a-build-machine-to-compile.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: Configuring a build machine in WPF DockingManager control | Syncfusion
-description: Configuring a build machine to compile projects after version v8.1.0.30 in Syncfusion WPF DockingManager control, its elements and more.
-platform: wpf
+title: Configuring a build machine in WPF DockingManager control | Syncfusion®
+description: Configuring a build machine to compile projects after version v8.1.0.30 in Syncfusion® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---
 
 # Configuring a build machine in WPF DockingManager control
 
-To compile projects that use Syncfusion controls in a build machine, Syncfusion helps to install the Link Install Setup. The setup installs Syncfusion assemblies into the target folder, and registers the product key to the registry. This allows you to compile a project, developed on a build machine. Please download the link install setup from the below location 
+To compile projects that use Syncfusion<sup>®</sup> controls in a build machine, Syncfusion<sup>®</sup> helps to install the Link Install Setup. The setup installs Syncfusion<sup>®</sup> assemblies into the target folder, and registers the product key to the registry. This allows you to compile a project, developed on a build machine. Please download the link install setup from the below location 
 
 [http://files2.syncfusion.com/installs/v9.1.0.20/essentialstudiolinkinstall.exe](http://files2.syncfusion.com/installs/v9.1.0.20/essentialstudiolinkinstall.exe)
 

--- a/wpf/Docking/How-to/Detect-the-closing-of-a-DockingManagerchild.md
+++ b/wpf/Docking/How-to/Detect-the-closing-of-a-DockingManagerchild.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Detect the closing of a DockingManagerchild in WPF | Syncfusion
-description: Detect the closing of a dockingmanagerchild in Syncfusion Essential Studio WPF, its elements and more.
-platform: wpf
+title: Detect the closing of a DockingManagerchild in WPF | Syncfusion®
+description: Detect the closing of a dockingmanagerchild in Syncfusion® Essential Studio® WPF, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Detect-whether-the-window-is-hosted-in-DockingManager.md
+++ b/wpf/Docking/How-to/Detect-whether-the-window-is-hosted-in-DockingManager.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Detect whether the window is hosted in WPF DockingManager | Syncfusion
-description: Detect whether the window is hosted in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Detect whether the window is hosted in WPF DockingManager | Syncfusion®
+description: Detect whether the window is hosted in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Disable-Drag-and-Drop-of-TDI-items.md
+++ b/wpf/Docking/How-to/Disable-Drag-and-Drop-of-TDI-items.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Disable Drag and Drop of TDI items | DockingManager | wpf | Syncfusion
-description: Disable drag and drop of tdi items in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Disable Drag and Drop of TDI items | DockingManager | wpf | Syncfusion®
+description: Disable drag and drop of tdi items in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Disable-TabGroup-Resize-Preview.md
+++ b/wpf/Docking/How-to/Disable-TabGroup-Resize-Preview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Disable TabGroup Resize Preview | DockingManager | wpf | Syncfusion
-description: Disable tabgroup resize preview in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Disable TabGroup Resize Preview | DockingManager | wpf | Syncfusion®
+description: Disable tabgroup resize preview in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Disable-the-Resize-of-FloatWindow.md
+++ b/wpf/Docking/How-to/Disable-the-Resize-of-FloatWindow.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Disable the Resize of FloatWindow | DockingManager | wpf | Syncfusion
-description: Disable the resize of floatwindow in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Disable the Resize of FloatWindow | DockingManager | wpf | Syncfusion®
+description: Disable the resize of floatwindow in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Enabledisable-TabItemContextMenu-and-TablistContextMenu.md
+++ b/wpf/Docking/How-to/Enabledisable-TabItemContextMenu-and-TablistContextMenu.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Enabledisable TabItemContextMenu in WPF DockingManager | Syncfusion
-description: Enabledisable tabitemcontextmenu and tablistcontextmenu in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Enabledisable TabItemContextMenu in WPF DockingManager | Syncfusion®
+description: Enabledisable tabitemcontextmenu and tablistcontextmenu in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Feature-to-resize-the-FloatWindow-dynamically-depend-on-child-size.md
+++ b/wpf/Docking/How-to/Feature-to-resize-the-FloatWindow-dynamically-depend-on-child-size.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Feature to resize the FloatWindow in WPF DockingManager | Syncfusion
-description: Feature to resize the floatwindow dynamically depend on child size in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Feature to resize the FloatWindow in WPF DockingManager | Syncfusion®
+description: Feature to resize the floatwindow dynamically depend on child size in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Hide-the-TDI-header-on-a-child.md
+++ b/wpf/Docking/How-to/Hide-the-TDI-header-on-a-child.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Hide the TDI header on a child | DockingManager | wpf | Syncfusion
-description: Hide the tdi header on a child in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Hide the TDI header on a child | DockingManager | wpf | Syncfusion®
+description: Hide the tdi header on a child in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Position-FloatWindow-using-FloatWindowRect.md
+++ b/wpf/Docking/How-to/Position-FloatWindow-using-FloatWindowRect.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Position FloatWindow in WPF DockingManager Control | Syncfusion
-description: Position floatwindow using floatwindowrect in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Position FloatWindow in WPF DockingManager Control | Syncfusion®
+description: Position floatwindow using floatwindowrect in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Remove-Individual-Menu-Items.md
+++ b/wpf/Docking/How-to/Remove-Individual-Menu-Items.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Remove Individual Menu Items | DockingManager | wpf | Syncfusion
-description: Remove individual menu items in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Remove Individual Menu Items | DockingManager | wpf | Syncfusion®
+description: Remove individual menu items in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Retrieve-the-AutoHidden-Window-height.md
+++ b/wpf/Docking/How-to/Retrieve-the-AutoHidden-Window-height.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Retrieve the AutoHidden Window in WPF DockingManager | Syncfusion
-description: Retrieve the autohidden window height in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Retrieve the AutoHidden Window in WPF DockingManager | Syncfusion®
+description: Retrieve the autohidden window height in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Set-ActiveWindow-using-SetNewFocusedElement.md
+++ b/wpf/Docking/How-to/Set-ActiveWindow-using-SetNewFocusedElement.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Set ActiveWindow using SetNewFocused in WPF DockingManager| Syncfusion
-description: Set activewindow using setnewfocusedelement in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Set ActiveWindow using SetNewFocused in WPF DockingManager| Syncfusion®
+description: Set activewindow using setnewfocusedelement in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Set-Header-Icon-for-MDI-Window.md
+++ b/wpf/Docking/How-to/Set-Header-Icon-for-MDI-Window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Set Header Icon for MDI Window | DockingManager | wpf | Syncfusion
-description: Set header icon for mdi window in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Set Header Icon for MDI Window | DockingManager | wpf | Syncfusion®
+description: Set header icon for mdi window in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Set-splitter-background-and-size.md
+++ b/wpf/Docking/How-to/Set-splitter-background-and-size.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Set splitter background and size | DockingManager | wpf | Syncfusion
-description: Set splitter background and size in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Set splitter background and size | DockingManager | wpf | Syncfusion®
+description: Set splitter background and size in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Unpin-all-AutoHide-window.md
+++ b/wpf/Docking/How-to/Unpin-all-AutoHide-window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Unpin all AutoHide window | DockingManager | wpf | Syncfusion
-description: Unpin all autohide window in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Unpin all AutoHide window | DockingManager | wpf | Syncfusion®
+description: Unpin all autohide window in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Use-FlipItems-property.md
+++ b/wpf/Docking/How-to/Use-FlipItems-property.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Use FlipItems property | DockingManager | wpf | Syncfusion
-description: Use flipitems property in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Use FlipItems property | DockingManager | wpf | Syncfusion®
+description: Use flipitems property in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Use-Host-under-the-mouse.md
+++ b/wpf/Docking/How-to/Use-Host-under-the-mouse.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Use Host under the mouse | DockingManager | wpf | Syncfusion
-description: Use host under the mouse in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Use Host under the mouse | DockingManager | wpf | Syncfusion®
+description: Use host under the mouse in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Using-of-IsDragging.md
+++ b/wpf/Docking/How-to/Using-of-IsDragging.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Using of IsDragging | DockingManager | wpf | Syncfusion
-description: Using of isdragging in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Using of IsDragging | DockingManager | wpf | Syncfusion®
+description: Using of isdragging in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/How-to/Using-the-FullScreen-mode.md
+++ b/wpf/Docking/How-to/Using-the-FullScreen-mode.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Using the FullScreen mode | DockingManager | wpf | Syncfusion
-description: Using the fullscreen mode in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Using the FullScreen mode | DockingManager | wpf | Syncfusion®
+description: Using the fullscreen mode in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Interactive-Features.md
+++ b/wpf/Docking/Interactive-Features.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Interactive Features | DockingManager | WPF | Syncfusion
-description: Interactive features of Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Interactive Features | DockingManager | WPF | Syncfusion®
+description: Interactive features of Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Linked-Manager.md
+++ b/wpf/Docking/Linked-Manager.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Linked Manager and Nested Docking in WPF Docking| Syncfusion
-description: Learn here all about Linked Manager and Nested Docking support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Linked Manager and Nested Docking in WPF Docking| Syncfusion®
+description: Learn here all about Linked Manager and Nested Docking support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Localization.md
+++ b/wpf/Docking/Localization.md
@@ -1,15 +1,15 @@
 ---
 layout: post
-title: Localization | DockingManager | WPF | Syncfusion
-description: Learn here about Localization in Syncfusion Essential Studio WPF DockingManager control, its elements and more.
-platform: wpf
+title: Localization | DockingManager | WPF | Syncfusion®
+description: Learn here about Localization in Syncfusion® Essential Studio® WPF DockingManager control, its elements and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---
 
 # Localization in WPF DockingManager control
 
-Localization customizes the application towards a specific language and region. Syncfusion Tools allow you to set custom resource through the Resx file. In the following table, DockingManager’s property is localized in English and French.
+Localization customizes the application towards a specific language and region. Syncfusion<sup>®</sup> Tools allow you to set custom resource through the Resx file. In the following table, DockingManager’s property is localized in English and French.
 
 <table>
 <tr>

--- a/wpf/Docking/MDI-TDI-functionalities.md
+++ b/wpf/Docking/MDI-TDI-functionalities.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: MDI/TDI functionalities in WPF Docking control | Syncfusion
-description: Learn here all about MDI/TDI functionalities support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: MDI/TDI functionalities in WPF Docking control | Syncfusion®
+description: Learn here all about MDI/TDI functionalities support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Other-Features.md
+++ b/wpf/Docking/Other-Features.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Other Features | DockingManager | WPF | Syncfusion
-description: Other features of Syncfusion Essential Studio WPF DockingManager control, its elements, features and more.
-platform: wpf
+title: Other Features | DockingManager | WPF | Syncfusion®
+description: Other features of Syncfusion® Essential Studio® WPF DockingManager control, its elements, features and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Overview.md
+++ b/wpf/Docking/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Docking control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Docking (DockingManager) control, its elements and more details.
-platform: wpf
+title: About WPF Docking control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Docking (DockingManager) control, its elements and more details.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Pattern-and-Practices.md
+++ b/wpf/Docking/Pattern-and-Practices.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Patterns and Practices in WPF Docking control | Syncfusion
-description: Learn here all about Patterns and Practices support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Patterns and Practices in WPF Docking control | Syncfusion®
+description: Learn here all about Patterns and Practices support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/State-Persistence.md
+++ b/wpf/Docking/State-Persistence.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: State Persistence in WPF Docking control | Syncfusion
-description: Learn here all about State Persistence support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: State Persistence in WPF Docking control | Syncfusion®
+description: Learn here all about State Persistence support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Styling-and-Templates.md
+++ b/wpf/Docking/Styling-and-Templates.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Styling and Templates in WPF Docking control | Syncfusion
-description: Learn here all about Styling and Templates support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Styling and Templates in WPF Docking control | Syncfusion®
+description: Learn here all about Styling and Templates support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Docking/Tabbed-Window.md
+++ b/wpf/Docking/Tabbed-Window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Tabbed Window in WPF Docking control | Syncfusion
-description: Learn here all about Tabbed Window support in Syncfusion WPF Docking (DockingManager) control and more.
-platform: wpf
+title: Tabbed Window in WPF Docking control | Syncfusion®
+description: Learn here all about Tabbed Window support in Syncfusion® WPF Docking (DockingManager) control and more.
+platform: WPF
 control: DockingManager
 documentation: ug
 ---

--- a/wpf/Domain-UpDown/Appearance-and-Styling.md
+++ b/wpf/Domain-UpDown/Appearance-and-Styling.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance and Styling in WPF Domain Updown control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion WPF Domain Updown (SfDomainUpDown) control and more.
-platform: wpf
+title: Appearance and Styling in WPF Domain Updown control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® WPF Domain Updown (SfDomainUpDown) control and more.
+platform: WPF
 control: DomainUpDown
 documentation: ug
 ---

--- a/wpf/Domain-UpDown/AutoReverse.md
+++ b/wpf/Domain-UpDown/AutoReverse.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: AutoReverse in WPF Domain Updown control | Syncfusion
-description: Learn here all about AutoReverse support in Syncfusion WPF Domain Updown (SfDomainUpDown) control and more.
-platform: wpf
+title: AutoReverse in WPF Domain Updown control | Syncfusion®
+description: Learn here all about AutoReverse support in Syncfusion® WPF Domain Updown (SfDomainUpDown) control and more.
+platform: WPF
 control: DomainUpDown
 documentation: ug
 ---

--- a/wpf/Domain-UpDown/Gestures.md
+++ b/wpf/Domain-UpDown/Gestures.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Gestures in WPF Domain Updown control | Syncfusion
-description: Learn here all about Gestures support in Syncfusion WPF Domain Updown (SfDomainUpDown) control and more.
-platform: wpf
+title: Gestures in WPF Domain Updown control | Syncfusion®
+description: Learn here all about Gestures support in Syncfusion® WPF Domain Updown (SfDomainUpDown) control and more.
+platform: WPF
 control: DomainUpDown
 documentation: ug
 ---

--- a/wpf/Domain-UpDown/Getting-Started.md
+++ b/wpf/Domain-UpDown/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Domain Updown control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Domain Updown (SfDomainUpDown) control, its elements and more details.
+title: Getting Started with WPF Domain Updown control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Domain Updown (SfDomainUpDown) control, its elements and more details.
 platform: WPF
 control: DomainUpDown
 documentation: ug

--- a/wpf/Domain-UpDown/Populating-Data.md
+++ b/wpf/Domain-UpDown/Populating-Data.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Populating Data in WPF Domain Updown control | Syncfusion
-description: Learn here all about Populating Data support in Syncfusion WPF Domain Updown (SfDomainUpDown) control and more.
-platform: wpf
+title: Populating Data in WPF Domain Updown control | Syncfusion®
+description: Learn here all about Populating Data support in Syncfusion® WPF Domain Updown (SfDomainUpDown) control and more.
+platform: WPF
 control: DomainUpDown
 documentation: ug
 ---

--- a/wpf/Domain-UpDown/Spin-Button-Alignment.md
+++ b/wpf/Domain-UpDown/Spin-Button-Alignment.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Spin Button Alignment in WPF Domain Updown control | Syncfusion
-description: Learn here all about Spin Button Alignment support in Syncfusion WPF Domain Updown (SfDomainUpDown) control and more.
-platform: wpf
+title: Spin Button Alignment in WPF Domain Updown control | Syncfusion®
+description: Learn here all about Spin Button Alignment support in Syncfusion® WPF Domain Updown (SfDomainUpDown) control and more.
+platform: WPF
 control: DomainUpDown
 documentation: ug
 ---

--- a/wpf/Double-TextBox/Appearance-and-Styling.md
+++ b/wpf/Double-TextBox/Appearance-and-Styling.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF Double TextBox control | Syncfusion
-description: Learn about Appearance support in Syncfusion WPF Double TextBox control, its elements and more details.
-platform: wpf
+title: Appearance in WPF Double TextBox control | Syncfusion®
+description: Learn about Appearance support in Syncfusion® WPF Double TextBox control, its elements and more details.
+platform: WPF
 control: DoubleTextBox
 documentation: ug
 ---

--- a/wpf/Double-TextBox/Changing-Double-Value.md
+++ b/wpf/Double-TextBox/Changing-Double-Value.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Changing Double Value in WPF Double TextBox control | Syncfusion
-description: Learn about Changing Double Value support in Syncfusion WPF Double TextBox control, its elements and more.
-platform: wpf
+title: Changing Double Value in WPF Double TextBox control | Syncfusion®
+description: Learn about Changing Double Value support in Syncfusion® WPF Double TextBox control, its elements and more.
+platform: WPF
 control: DoubleTextBox 
 documentation: ug
 ---

--- a/wpf/Double-TextBox/Culture-and-Number-Formats.md
+++ b/wpf/Double-TextBox/Culture-and-Number-Formats.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Culture and Formatting in WPF Double TextBox control | Syncfusion
-description: Learn about Culture and Formatting support in Syncfusion WPF Double TextBox control, its elements and more.
-platform: wpf
+title: Culture and Formatting in WPF Double TextBox control | Syncfusion®
+description: Learn about Culture and Formatting support in Syncfusion® WPF Double TextBox control, its elements and more.
+platform: WPF
 control: DoubleTextBox
 documentation: ug
 ---

--- a/wpf/Double-TextBox/Getting-Started.md
+++ b/wpf/Double-TextBox/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF Double TextBox control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF Double TextBox control, its elements and more details.
-platform: wpf
+title: Getting Started with WPF Double TextBox control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF Double TextBox control, its elements and more details.
+platform: WPF
 control: DoubleTextBox
 documentation: ug
 ---
@@ -34,7 +34,7 @@ To add the DoubleTextBox control manually in XAML, follow these steps:
 
 2. Add the **Syncfusion.Shared.WPF** assembly references to the project.
  
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** and declare the `DoubleTextBox` control in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** and declare the `DoubleTextBox` control in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Double-TextBox/Overview.md
+++ b/wpf/Double-TextBox/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Double TextBox control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Double TextBox control, its elements and more details.
-platform: wpf
+title: About WPF Double TextBox control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Double TextBox control, its elements and more details.
+platform: WPF
 control: DoubleTextBox
 documentation: ug
 ---

--- a/wpf/Double-TextBox/Range-Adorner.md
+++ b/wpf/Double-TextBox/Range-Adorner.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Range Adorner in WPF Double TextBox control | Syncfusion
-description: Learn about Range Adorner support in Syncfusion WPF Double TextBox control, its elements and more details.
-platform: wpf
+title: Range Adorner in WPF Double TextBox control | Syncfusion®
+description: Learn about Range Adorner support in Syncfusion® WPF Double TextBox control, its elements and more details.
+platform: WPF
 control: DoubleTextBox 
 documentation: ug
 ---

--- a/wpf/Double-TextBox/Restriction-or-Validation.md
+++ b/wpf/Double-TextBox/Restriction-or-Validation.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Restriction or Validation in WPF Double TextBox control | Syncfusion
-description: Learn about Restriction or Validation support in Syncfusion WPF Double TextBox control, its elements and more.
-platform: wpf
+title: Restriction or Validation in WPF Double TextBox control | Syncfusion®
+description: Learn about Restriction or Validation support in Syncfusion® WPF Double TextBox control, its elements and more.
+platform: WPF
 control: DoubleTextBox 
 documentation: ug
 ---

--- a/wpf/Double-TextBox/Step-Interval.md
+++ b/wpf/Double-TextBox/Step-Interval.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Step Interval in WPF Double TextBox control | Syncfusion
-description: Learn about Step Interval support in Syncfusion WPF Double TextBox control, its elements and more details.
-platform: wpf
+title: Step Interval in WPF Double TextBox control | Syncfusion®
+description: Learn about Step Interval support in Syncfusion® WPF Double TextBox control, its elements and more details.
+platform: WPF
 control: DoubleTextBox 
 documentation: ug
 ---

--- a/wpf/GridSplitter/Appearance.md
+++ b/wpf/GridSplitter/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF GridSplitter control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF GridSplitter (SfGridSplitter) control and more.
-platform: wpf
+title: Appearance in WPF GridSplitter control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF GridSplitter (SfGridSplitter) control and more.
+platform: WPF
 control: SfGridSplitter
 documentation: ug
 ---

--- a/wpf/GridSplitter/Getting-Started.md
+++ b/wpf/GridSplitter/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF GridSplitter control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF GridSplitter (SfGridSplitter) control, its elements and more details.
+title: Getting Started with WPF GridSplitter control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF GridSplitter (SfGridSplitter) control, its elements and more details.
 platform: WPF
 control: SfGridSplitter
 documentation: ug
@@ -34,7 +34,7 @@ To add the control manually in XAML, follow the given steps:
 1. Add the following required assembly references to the project:
     * Syncfusion.SfInput.WPF
     * Syncfusion.SfShared.WPF
-2. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
+2. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
 3. Declare the `SfGridSplitter` control in the XAML page.
 
 {% capture codesnippet1 %}

--- a/wpf/GridSplitter/Overview.md
+++ b/wpf/GridSplitter/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF GridSplitter control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF GridSplitter (SfGridSplitter) control, its elements and more details.
-platform: wpf
+title: About WPF GridSplitter control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF GridSplitter (SfGridSplitter) control, its elements and more details.
+platform: WPF
 control: SfGridSplitter
 documentation: ug
 ---

--- a/wpf/Integer-TextBox/Appearance.md
+++ b/wpf/Integer-TextBox/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF IntegerTextBox control | Syncfusion
-description: Learn about Appearance support in Syncfusion WPF IntegerTextBox control and more details about the control features.
-platform: wpf
+title: Appearance in WPF IntegerTextBox control | Syncfusion®
+description: Learn about Appearance support in Syncfusion® WPF IntegerTextBox control and more details about the control features.
+platform: WPF
 control: IntegerTextBox
 documentation: ug
 ---

--- a/wpf/Integer-TextBox/Changing-Integer-Value.md
+++ b/wpf/Integer-TextBox/Changing-Integer-Value.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Changing Integer Value in WPF IntegerTextBox control | Syncfusion
-description: Learn here about Changing Integer Value with Syncfusion WPF IntegerTextBox control and more details about the control features.
-platform: wpf
+title: Changing Integer Value in WPF IntegerTextBox control | Syncfusion®
+description: Learn here about Changing Integer Value with Syncfusion® WPF IntegerTextBox control and more details about the control features.
+platform: WPF
 control: IntegerTextBox 
 documentation: ug
 ---

--- a/wpf/Integer-TextBox/Culture-and-Number-Formats.md
+++ b/wpf/Integer-TextBox/Culture-and-Number-Formats.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Culture and Formatting in WPF IntegerTextBox control | Syncfusion
-description: Learn about Culture and Formatting support in Syncfusion WPF IntegerTextBox control and more details about the control features.
-platform: wpf
+title: Culture and Formatting in WPF IntegerTextBox control | Syncfusion®
+description: Learn about Culture and Formatting support in Syncfusion® WPF IntegerTextBox control and more details about the control features.
+platform: WPF
 control: IntegerTextBox 
 documentation: ug
 ---

--- a/wpf/Integer-TextBox/Getting-Started.md
+++ b/wpf/Integer-TextBox/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting started with WPF IntegerTextBox control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF IntegerTextBox control and more details about the control features.
-platform: wpf
+title: Getting started with WPF IntegerTextBox control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF IntegerTextBox control and more details about the control features.
+platform: WPF
 control: IntegerTextBox 
 documentation: ug
 ---
@@ -34,7 +34,7 @@ To add the IntegerTextBox control manually in XAML, follow these steps:
 
 2. Add the **Syncfusion.Shared.WPF** assembly references to the project.
  
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** and declare the `IntegerTextBox` control in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** and declare the `IntegerTextBox` control in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Integer-TextBox/Overview.md
+++ b/wpf/Integer-TextBox/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About WPF IntegerTextBox control | Syncfusion 
-description: Learn about introduction of Syncfusion WPF IntegerTextBox control and more details about the control features.
+title: About WPF IntegerTextBox control | Syncfusion® 
+description: Learn about introduction of Syncfusion® WPF IntegerTextBox control and more details about the control features.
 platform: WPF
 control: IntegerTextBox 
 documentation: ug

--- a/wpf/Integer-TextBox/Range-Adorner.md
+++ b/wpf/Integer-TextBox/Range-Adorner.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Range Adorner in WPF IntegerTextBox control | Syncfusion
-description: Learn about Range Adorner support in Syncfusion WPF IntegerTextBox control and more details about the control features.
-platform: wpf
+title: Range Adorner in WPF IntegerTextBox control | Syncfusion®
+description: Learn about Range Adorner support in Syncfusion® WPF IntegerTextBox control and more details about the control features.
+platform: WPF
 control: IntegerTextBox 
 documentation: ug
 ---

--- a/wpf/Integer-TextBox/Restriction-or-Validation.md
+++ b/wpf/Integer-TextBox/Restriction-or-Validation.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Restriction or Validation in WPF IntegerTextBox control | Syncfusion
-description: Learn about Restriction or Validation support in Syncfusion WPF IntegerTextBox control and more details about the control features.
-platform: wpf
+title: Restriction or Validation in WPF IntegerTextBox control | Syncfusion®
+description: Learn about Restriction or Validation support in Syncfusion® WPF IntegerTextBox control and more details about the control features.
+platform: WPF
 control: IntegerTextBox 
 documentation: ug
 ---

--- a/wpf/Integer-TextBox/Step-Interval.md
+++ b/wpf/Integer-TextBox/Step-Interval.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Step Interval in  control | Syncfusion
-description: Learn about Step Interval support in Syncfusion WPF IntegerTextBox control and more details about the control features.WPF IntegerTextBox
-platform: wpf
+title: Step Interval in  control | Syncfusion®
+description: Learn about Step Interval support in Syncfusion® WPF IntegerTextBox control and more details about the control features.WPF IntegerTextBox
+platform: WPF
 control: IntegerTextBox 
 documentation: ug
 ---

--- a/wpf/MaskedTextBox/Appearance.md
+++ b/wpf/MaskedTextBox/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF MaskedTextBox control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF MaskedTextBox (SfMaskedEdit) control and more.
-platform: wpf
+title: Appearance in WPF MaskedTextBox control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF MaskedTextBox (SfMaskedEdit) control and more.
+platform: WPF
 control: SfMaskedEdit
 documentation: ug
 ---

--- a/wpf/MaskedTextBox/Getting-Started.md
+++ b/wpf/MaskedTextBox/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF MaskedTextBox control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF MaskedTextBox (SfMaskedEdit) control, its elements and more details.
+title: Getting Started with WPF MaskedTextBox control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF MaskedTextBox (SfMaskedEdit) control, its elements and more details.
 platform: WPF
 control: SfMaskedEdit
 documentation: ug
@@ -42,7 +42,7 @@ To add the `SfMaskedEdit` control manually in XAML, follow these steps:
     * Syncfusion.SfInput.WPF
     * Syncfusion.SfShared.WPF
  
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** and declare the `SfMaskedEdit` control in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** and declare the `SfMaskedEdit` control in XAML page.
 
 4. Declare the `SfMaskedEdit` control in XAML page.
 

--- a/wpf/MaskedTextBox/Input-Restriction.md
+++ b/wpf/MaskedTextBox/Input-Restriction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Input Restriction in WPF MaskedTextBox control | Syncfusion
-description: Learn here all about Input Restriction support in Syncfusion WPF MaskedTextBox (SfMaskedEdit) control and more.
+title: Input Restriction in WPF MaskedTextBox control | Syncfusion®
+description: Learn here all about Input Restriction support in Syncfusion® WPF MaskedTextBox (SfMaskedEdit) control and more.
 platform: WPF
 control: SfMaskedEdit
 documentation: ug

--- a/wpf/MaskedTextBox/Overview.md
+++ b/wpf/MaskedTextBox/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF MaskedTextBox control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF MaskedTextBox (SfMaskedEdit) control, its elements and more details.
-platform: wpf
+title: About WPF MaskedTextBox control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF MaskedTextBox (SfMaskedEdit) control, its elements and more details.
+platform: WPF
 control: SfMaskedEdit
 documentation: ug
 ---

--- a/wpf/NumericUpdown/Formatting.md
+++ b/wpf/NumericUpdown/Formatting.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Number Formatting in WPF NumericUpdown control | Syncfusion
-description: Learn here all about Number Formatting support in Syncfusion WPF NumericUpdown (UpDown) control and more.
-platform: wpf
+title: Number Formatting in WPF NumericUpdown control | Syncfusion®
+description: Learn here all about Number Formatting support in Syncfusion® WPF NumericUpdown (UpDown) control and more.
+platform: WPF
 control: UpDown
 documentation: ug
 ---

--- a/wpf/NumericUpdown/Getting-Started.md
+++ b/wpf/NumericUpdown/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF NumericUpdown control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF NumericUpdown (UpDown) control, its elements and more details.
-platform: wpf
+title: Getting Started with WPF NumericUpdown control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF NumericUpdown (UpDown) control, its elements and more details.
+platform: WPF
 control: UpDown
 documentation: ug
 ---
@@ -45,7 +45,7 @@ In order to add the [UpDown](https://help.syncfusion.com/cr/wpf/Syncfusion.Windo
 
     * Syncfusion.Shared.WPF
 
-3. Import Syncfusion WPF schema http://schemas.syncfusion.com/wpf and declare the UpDown control in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema http://schemas.syncfusion.com/wpf and declare the UpDown control in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/NumericUpdown/Interaction.md
+++ b/wpf/NumericUpdown/Interaction.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Interaction in WPF NumericUpdown control | Syncfusion
-description: Learn here all about Interaction support in Syncfusion WPF NumericUpdown (UpDown) control, its elements and more details.
-platform: wpf
+title: Interaction in WPF NumericUpdown control | Syncfusion®
+description: Learn here all about Interaction support in Syncfusion® WPF NumericUpdown (UpDown) control, its elements and more details.
+platform: WPF
 control: UpDown
 documentation: ug
 ---

--- a/wpf/NumericUpdown/Overview.md
+++ b/wpf/NumericUpdown/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About WPF NumericUpdown control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF NumericUpdown (UpDown) control, its elements and more details.
+title: About WPF NumericUpdown control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF NumericUpdown (UpDown) control, its elements and more details.
 platform: WPF
 control: UpDown
 documentation: ug

--- a/wpf/NumericUpdown/Restriction.md
+++ b/wpf/NumericUpdown/Restriction.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Restriction in WPF NumericUpdown control | Syncfusion
-description: Learn here all about Restriction support in Syncfusion WPF NumericUpdown (UpDown) control, its elements and more details.
-platform: wpf
+title: Restriction in WPF NumericUpdown control | Syncfusion®
+description: Learn here all about Restriction support in Syncfusion® WPF NumericUpdown (UpDown) control, its elements and more details.
+platform: WPF
 control: UpDown
 documentation: ug
 ---

--- a/wpf/NumericUpdown/Styles-and-Templates.md
+++ b/wpf/NumericUpdown/Styles-and-Templates.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Styles and Templates in WPF NumericUpdown control | Syncfusion
-description: Learn here all about Styles and Templates support in Syncfusion WPF NumericUpdown (UpDown) control and more.
-platform: wpf
+title: Styles and Templates in WPF NumericUpdown control | Syncfusion®
+description: Learn here all about Styles and Templates support in Syncfusion® WPF NumericUpdown (UpDown) control and more.
+platform: WPF
 control: UpDown
 documentation: ug
 ---

--- a/wpf/Percent-TextBox/Appearance.md
+++ b/wpf/Percent-TextBox/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF Percent TextBox control | Syncfusion
-description: Learn about Appearance support in Syncfusion Essential Studio WPF Percent TextBox control, its elements and more.
-platform: wpf
+title: Appearance in WPF Percent TextBox control | Syncfusion®
+description: Learn about Appearance support in Syncfusion® Essential Studio® WPF Percent TextBox control, its elements and more.
+platform: WPF
 control: PercentTextBox
 documentation: ug
 ---

--- a/wpf/Percent-TextBox/Changing-Percent-Value.md
+++ b/wpf/Percent-TextBox/Changing-Percent-Value.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Changing Percent Value in WPF Percent TextBox control | Syncfusion
-description: Learn about Changing Percent Value support in Syncfusion WPF Percent TextBox control, its elements and more.
-platform: wpf
+title: Changing Percent Value in WPF Percent TextBox control | Syncfusion®
+description: Learn about Changing Percent Value support in Syncfusion® WPF Percent TextBox control, its elements and more.
+platform: WPF
 control: PercentTextBox 
 documentation: ug
 ---

--- a/wpf/Percent-TextBox/Culture-and-Number-Formats.md
+++ b/wpf/Percent-TextBox/Culture-and-Number-Formats.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Culture and Formatting in WPF Percent TextBox control | Syncfusion
-description: Learn about Culture and Formatting support in Syncfusion WPF Percent TextBox control, its elements and more.
-platform: wpf
+title: Culture and Formatting in WPF Percent TextBox control | Syncfusion®
+description: Learn about Culture and Formatting support in Syncfusion® WPF Percent TextBox control, its elements and more.
+platform: WPF
 control: PercentTextBox
 documentation: ug
 ---

--- a/wpf/Percent-TextBox/Getting-Started.md
+++ b/wpf/Percent-TextBox/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Percent TextBox control | Syncfusion
-description: Learn here about getting started with Syncfusion Essential Studio WPF Percent TextBox control, its elements and more.
+title: Getting Started with WPF Percent TextBox control | Syncfusion®
+description: Learn here about getting started with Syncfusion® Essential Studio® WPF Percent TextBox control, its elements and more.
 platform: WPF
 control: PercentTextBox
 documentation: ug
@@ -34,7 +34,7 @@ To add the PercentTextBox control manually in XAML, follow these steps:
 
 2. Add the **Syncfusion.Shared.WPF** assembly references to the project.
  
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** and declare the `PercentTextBox` control in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** and declare the `PercentTextBox` control in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Percent-TextBox/Overview.md
+++ b/wpf/Percent-TextBox/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About WPF Percent TextBox control | Syncfusion
-description: Learn here all about introduction of Syncfusion Essential Studio WPF Percent TextBox control, its elements and more.
+title: About WPF Percent TextBox control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® Essential Studio® WPF Percent TextBox control, its elements and more.
 platform: WPF
 control: PercentTextBox 
 documentation: ug

--- a/wpf/Percent-TextBox/Range-Adorner.md
+++ b/wpf/Percent-TextBox/Range-Adorner.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Range Adorner in WPF Percent TextBox control | Syncfusion
-description: Learn about Range Adorner support in Syncfusion Essential Studio WPF Percent TextBox control, its elements and more.
-platform: wpf
+title: Range Adorner in WPF Percent TextBox control | Syncfusion®
+description: Learn about Range Adorner support in Syncfusion® Essential Studio® WPF Percent TextBox control, its elements and more.
+platform: WPF
 control: PercentTextBox 
 documentation: ug
 ---

--- a/wpf/Percent-TextBox/Restriction-or-Validation.md
+++ b/wpf/Percent-TextBox/Restriction-or-Validation.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Restriction or Validation in WPF Percent TextBox control | Syncfusion
-description: Learn about Restriction or Validation support in Syncfusion WPF Percent TextBox control, its elements and more.
-platform: wpf
+title: Restriction or Validation in WPF Percent TextBox control | Syncfusion®
+description: Learn about Restriction or Validation support in Syncfusion® WPF Percent TextBox control, its elements and more.
+platform: WPF
 control: PercentTextBox 
 documentation: ug
 ---

--- a/wpf/Percent-TextBox/Step-Interval.md
+++ b/wpf/Percent-TextBox/Step-Interval.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Step Interval in WPF Percent TextBox control | Syncfusion
-description: Learn about Step Interval support in Syncfusion Essential Studio WPF Percent TextBox control, its elements and more.
-platform: wpf
+title: Step Interval in WPF Percent TextBox control | Syncfusion®
+description: Learn about Step Interval support in Syncfusion® Essential Studio® WPF Percent TextBox control, its elements and more.
+platform: WPF
 control: PercentTextBox 
 documentation: ug
 ---

--- a/wpf/PinnableListBox/Appearance.md
+++ b/wpf/PinnableListBox/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance | PinnableListBox | wpf | Syncfusion
-description: Learn here about Appearance in Syncfusion Essential Studio WPF PinnableListBox control, its elements, and more.
-platform: wpf
+title: Appearance | PinnableListBox | wpf | Syncfusion®
+description: Learn here about Appearance in Syncfusion® Essential Studio® WPF PinnableListBox control, its elements, and more.
+platform: WPF
 control: PinnableListBox 
 documentation: ug
 ---

--- a/wpf/PinnableListBox/Binding-Support.md
+++ b/wpf/PinnableListBox/Binding-Support.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Binding Support | PinnableListBox | wpf | Syncfusion
-description: Learn here about Binding support in Syncfusion Essential Studio WPF PinnableListBox control, its elements, and more.
-platform: wpf
+title: Binding Support | PinnableListBox | wpf | Syncfusion®
+description: Learn here about Binding support in Syncfusion® Essential Studio® WPF PinnableListBox control, its elements, and more.
+platform: WPF
 control: PinnableListBox 
 documentation: ug
 ---

--- a/wpf/PinnableListBox/Getting-Started.md
+++ b/wpf/PinnableListBox/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF PinnableListBox control | Syncfusion
-description: Learn here about getting started with Syncfusion Essential Studio WPF PinnableListBox control, its elements and more.
+title: Getting Started with WPF PinnableListBox control | Syncfusion®
+description: Learn here about getting started with Syncfusion® Essential Studio® WPF PinnableListBox control, its elements and more.
 platform: WPF
 control: PinnableListBox
 documentation: ug
@@ -36,7 +36,7 @@ The PinnableListBox control can be added to an application by dragging it from t
 To add the control manually in XAML, follow the given steps:
 
 1. Add the **Syncfusion.Shared.WPF** assembly reference to the project.
-2. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
+2. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
 3. Declare the PinnableListBox control in the XAML page.
 
 {% tabs %}

--- a/wpf/PinnableListBox/Overview.md
+++ b/wpf/PinnableListBox/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF PinnableListBox control | Syncfusion
-description: Learn here all about introduction of Syncfusion Essential Studio WPF PinnableListBox control, its elements and more.
-platform: wpf
+title: About WPF PinnableListBox control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® Essential Studio® WPF PinnableListBox control, its elements and more.
+platform: WPF
 control: PinnableListBox
 documentation: ug
 ---

--- a/wpf/Ribbon/ApplicationMenu.md
+++ b/wpf/Ribbon/ApplicationMenu.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Application Menu in WPF Ribbon control | Syncfusion
-description: Learn about Application Menu support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Application Menu in WPF Ribbon control | Syncfusion®
+description: Learn about Application Menu support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/Backstage.md
+++ b/wpf/Ribbon/Backstage.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Backstage in WPF Ribbon control | Syncfusion
-description: Learn about Backstage support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Backstage in WPF Ribbon control | Syncfusion®
+description: Learn about Backstage support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/CreatingRibbonModelTab.md
+++ b/wpf/Ribbon/CreatingRibbonModelTab.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Ribbon ModelTab in WPF Ribbon control | Syncfusion
-description: Learn about Ribbon ModelTab support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Ribbon ModelTab in WPF Ribbon control | Syncfusion®
+description: Learn about Ribbon ModelTab support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/DealingWithRibbon.md
+++ b/wpf/Ribbon/DealingWithRibbon.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Dealing with Ribbon in WPF Ribbon control | Syncfusion
-description: Learn about Dealing with Ribbon support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Dealing with Ribbon in WPF Ribbon control | Syncfusion®
+description: Learn about Dealing with Ribbon support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/DealingWithRibbonItems.md
+++ b/wpf/Ribbon/DealingWithRibbonItems.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Dealing with Ribbon Items in WPF Ribbon control | Syncfusion
-description: Learn about Dealing with Ribbon Items support in Syncfusion WPF Ribbon control, its elements and more.
-platform: wpf
+title: Dealing with Ribbon Items in WPF Ribbon control | Syncfusion®
+description: Learn about Dealing with Ribbon Items support in Syncfusion® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/GettingStarted.md
+++ b/wpf/Ribbon/GettingStarted.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF Ribbon control | Syncfusion
-description: Learn here about getting started with Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Getting Started with WPF Ribbon control | Syncfusion®
+description: Learn here about getting started with Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---
@@ -12,7 +12,7 @@ This section explains how to implement a similar UI as Microsoft Outlook using R
 
 ## Add ribbon
 
-There are several ways to add Syncfusion control in to Visual Studio WPF project, the following steps will helps to add a Ribbon control through XAML Code.
+There are several ways to add Syncfusion<sup>®</sup> control in to Visual Studio WPF project, the following steps will helps to add a Ribbon control through XAML Code.
 
 * Create a WPF project in Visual Studio and refer the following assemblies.
 

--- a/wpf/Ribbon/How-To/Handle-event-to-Open-or-Close-the-PopUp-of-ApplicationMenu.md
+++ b/wpf/Ribbon/How-To/Handle-event-to-Open-or-Close-the-PopUp-of-ApplicationMenu.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Handle PopUp opening and Closing event in WPF Ribbon | Syncfusion
-description: handle event to detect the opening and closing of applicationmenu in Syncfusion WPF Ribbon control, its elements and more.
-platform: wpf
+title: Handle PopUp opening and Closing event in WPF Ribbon | Syncfusion®
+description: handle event to detect the opening and closing of applicationmenu in Syncfusion® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/KeyBoardSupport.md
+++ b/wpf/Ribbon/KeyBoardSupport.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: KeyBoard Support in WPF Ribbon control | Syncfusion
-description: Learn about KeyBoard Support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: KeyBoard Support in WPF Ribbon control | Syncfusion®
+description: Learn about KeyBoard Support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/Overview.md
+++ b/wpf/Ribbon/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Ribbon control | Syncfusion
-description: Learn here all about introduction of Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: About WPF Ribbon control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/PatternsAndPractices.md
+++ b/wpf/Ribbon/PatternsAndPractices.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Patterns and Practices in WPF Ribbon control | Syncfusion
-description: Learn about Patterns and Practices support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Patterns and Practices in WPF Ribbon control | Syncfusion®
+description: Learn about Patterns and Practices support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonButton.md
+++ b/wpf/Ribbon/RibbonButton.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonButton in WPF Ribbon control | Syncfusion
-description: Learn about RibbonButton support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonButton in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonButton support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonCheckBox.md
+++ b/wpf/Ribbon/RibbonCheckBox.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonCheckBox in WPF Ribbon control | Syncfusion
-description: Learn about RibbonCheckBox support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonCheckBox in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonCheckBox support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonComboBox.md
+++ b/wpf/Ribbon/RibbonComboBox.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonComboBox in WPF Ribbon control | Syncfusion
-description: Learn about RibbonComboBox support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonComboBox in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonComboBox support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonCustomization.md
+++ b/wpf/Ribbon/RibbonCustomization.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Quick Access ToolBar in WPF Ribbon control | Syncfusion
-description: Learn about Quick Access ToolBar support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Quick Access ToolBar in WPF Ribbon control | Syncfusion®
+description: Learn about Quick Access ToolBar support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonDropDownButton.md
+++ b/wpf/Ribbon/RibbonDropDownButton.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonDropDownButton in WPF Ribbon control | Syncfusion
-description: Learn about RibbonDropDownButton support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonDropDownButton in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonDropDownButton support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonGallery.md
+++ b/wpf/Ribbon/RibbonGallery.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonGallery in WPF Ribbon control | Syncfusion
-description: Learn about RibbonGallery support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonGallery in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonGallery support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonItemHost.md
+++ b/wpf/Ribbon/RibbonItemHost.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonItemHost in WPF Ribbon control | Syncfusion
-description: Learn about RibbonItemHost support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonItemHost in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonItemHost support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonListBox.md
+++ b/wpf/Ribbon/RibbonListBox.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonListBox in WPF Ribbon control | Syncfusion
-description: Learn about RibbonListBox support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonListBox in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonListBox support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonMenuItem.md
+++ b/wpf/Ribbon/RibbonMenuItem.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonMenuItem in WPF Ribbon control | Syncfusion
-description: Learn about RibbonMenuItem support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonMenuItem in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonMenuItem support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonMerge.md
+++ b/wpf/Ribbon/RibbonMerge.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Ribbon Merge in WPF Ribbon control | Syncfusion
-description: Learn about Ribbon Merge support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Ribbon Merge in WPF Ribbon control | Syncfusion®
+description: Learn about Ribbon Merge support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonRadioButton.md
+++ b/wpf/Ribbon/RibbonRadioButton.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonRadioButton in WPF Ribbon control | Syncfusion
-description: Learn about RibbonRadioButton support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonRadioButton in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonRadioButton support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonSeparator.md
+++ b/wpf/Ribbon/RibbonSeparator.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonSeparator in WPF Ribbon control | Syncfusion
-description: Learn about RibbonSeparator support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonSeparator in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonSeparator support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonSplitButton.md
+++ b/wpf/Ribbon/RibbonSplitButton.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonSplitButton in WPF Ribbon control | Syncfusion
-description: Learn about RibbonSplitButton support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonSplitButton in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonSplitButton support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonStatusBar.md
+++ b/wpf/Ribbon/RibbonStatusBar.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonStatusBar in WPF Ribbon control | Syncfusion
-description: Learn about RibbonStatusBar support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonStatusBar in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonStatusBar support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonTabPanelItem.md
+++ b/wpf/Ribbon/RibbonTabPanelItem.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonTabPanelItem in WPF Ribbon control | Syncfusion
-description: Learn about RibbonTabPanelItem support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonTabPanelItem in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonTabPanelItem support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/RibbonTextBox.md
+++ b/wpf/Ribbon/RibbonTextBox.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: RibbonTextBox in WPF Ribbon control | Syncfusion
-description: Learn about RibbonTextBox support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: RibbonTextBox in WPF Ribbon control | Syncfusion®
+description: Learn about RibbonTextBox support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/SimpleMenuButton.md
+++ b/wpf/Ribbon/SimpleMenuButton.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: SimpleMenuButton in WPF Ribbon control | Syncfusion
-description: Learn about SimpleMenuButton support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: SimpleMenuButton in WPF Ribbon control | Syncfusion®
+description: Learn about SimpleMenuButton support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/SimplifiedLayout.md
+++ b/wpf/Ribbon/SimplifiedLayout.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Simplified Layout in WPF Ribbon control | Syncfusion
-description: Learn about Simplified Layout support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Simplified Layout in WPF Ribbon control | Syncfusion®
+description: Learn about Simplified Layout support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/StatePersistence.md
+++ b/wpf/Ribbon/StatePersistence.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Serialization and Deserialization in WPF Ribbon control | Syncfusion
-description: Learn about Serialization and Deserialization support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Serialization and Deserialization in WPF Ribbon control | Syncfusion®
+description: Learn about Serialization and Deserialization support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/StylingAndTemplates.md
+++ b/wpf/Ribbon/StylingAndTemplates.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Styling and Templates in WPF Ribbon control | Syncfusion
-description: Learn about Styling and Templates support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Styling and Templates in WPF Ribbon control | Syncfusion®
+description: Learn about Styling and Templates support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/ToolTipSupport.md
+++ b/wpf/Ribbon/ToolTipSupport.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: ToolTip in WPF Ribbon control | Syncfusion
-description: Learn about ToolTip support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: ToolTip in WPF Ribbon control | Syncfusion®
+description: Learn about ToolTip support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/Ribbon/TouchSupport.md
+++ b/wpf/Ribbon/TouchSupport.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Touch Support in WPF Ribbon control | Syncfusion
-description: Learn here about Touch Support in Syncfusion Essential Studio WPF Ribbon control, its elements and more.
-platform: wpf
+title: Touch Support in WPF Ribbon control | Syncfusion®
+description: Learn here about Touch Support in Syncfusion® Essential Studio® WPF Ribbon control, its elements and more.
+platform: WPF
 control: Ribbon
 documentation: ug
 ---

--- a/wpf/SpellChecker/Appearance.md
+++ b/wpf/SpellChecker/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF SpellChecker control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF SpellChecker (SfSpellChecker) control and more.
-platform: wpf
+title: Appearance in WPF SpellChecker control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF SpellChecker (SfSpellChecker) control and more.
+platform: WPF
 control: SfSpellChecker
 documentation: ug
 ---

--- a/wpf/SpellChecker/Getting-Started.md
+++ b/wpf/SpellChecker/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF SpellChecker control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF SpellChecker (SfSpellChecker) control, its elements and more.
+title: Getting Started with WPF SpellChecker control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF SpellChecker (SfSpellChecker) control, its elements and more.
 platform: WPF
 control: SfSpellChecker
 documentation: ug

--- a/wpf/SpellChecker/Overview.md
+++ b/wpf/SpellChecker/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About WPF SpellChecker control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF SpellChecker (SfSpellChecker) control, its elements and more.
+title: About WPF SpellChecker control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF SpellChecker (SfSpellChecker) control, its elements and more.
 platform: WPF
 control: SfSpellChecker 
 documentation: ug

--- a/wpf/SpellChecker/custom-dictionary-support.md
+++ b/wpf/SpellChecker/custom-dictionary-support.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Custom Dictionary in WPF SpellChecker control | Syncfusion
-description: Learn here all about Custom Dictionary support in Syncfusion WPF SpellChecker (SfSpellChecker) control and more.
+title: Custom Dictionary in WPF SpellChecker control | Syncfusion®
+description: Learn here all about Custom Dictionary support in Syncfusion® WPF SpellChecker (SfSpellChecker) control and more.
 platform: WPF
 control: SfSpellChecker
 documentation: ug

--- a/wpf/Split-Button/Command-Binding.md
+++ b/wpf/Split-Button/Command-Binding.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Command Binding in WPF Split Button control | Syncfusion
-description: Learn about Command Binding support in Syncfusion Essential Studio WPF Split Button control, its elements and more.
-platform: wpf
+title: Command Binding in WPF Split Button control | Syncfusion®
+description: Learn about Command Binding support in Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
+platform: WPF
 control: SplitButtonAdv
 documentation: ug
 ---

--- a/wpf/Split-Button/Data-Binding.md
+++ b/wpf/Split-Button/Data-Binding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Data Binding in WPF Split Button control | Syncfusion
-description: Learn about Data Binding support in Syncfusion Essential Studio WPF Split Button control, its elements and more.
+title: Data Binding in WPF Split Button control | Syncfusion®
+description: Learn about Data Binding support in Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
 platform: WPF
 control: SplitButtonAdv
 documentation: ug

--- a/wpf/Split-Button/Dropdown-Direction.md
+++ b/wpf/Split-Button/Dropdown-Direction.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Dropdown Direction in WPF Split Button control | Syncfusion
-description: Learn about Dropdown Direction support in Syncfusion Essential Studio WPF Split Button control, its elements and more.
-platform: wpf
+title: Dropdown Direction in WPF Split Button control | Syncfusion®
+description: Learn about Dropdown Direction support in Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
+platform: WPF
 control: SplitButtonAdv
 documentation: ug
 ---

--- a/wpf/Split-Button/Dropdown-Menu-Items.md
+++ b/wpf/Split-Button/Dropdown-Menu-Items.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Dropdown Menu Items in WPF Split Button Control | Syncfusion
-description: Learn here all about dropdown menu items support in Syncfusion Essential Studio WPF Split Button control, its elements and more.
-platform: wpf
+title: Dropdown Menu Items in WPF Split Button Control | Syncfusion®
+description: Learn here all about dropdown menu items support in Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
+platform: WPF
 control: SplitButtonAdv
 documentation: ug
 ---

--- a/wpf/Split-Button/Events.md
+++ b/wpf/Split-Button/Events.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Events in WPF Split Button control | Syncfusion
-description: Learn about Events support in Syncfusion Essential Studio WPF Split Button control, its elements and more.
-platform: wpf
+title: Events in WPF Split Button control | Syncfusion®
+description: Learn about Events support in Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
+platform: WPF
 control: SplitButtonAdv
 documentation: ug
 ---

--- a/wpf/Split-Button/Getting-Started.md
+++ b/wpf/Split-Button/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF Split Button control | Syncfusion
-description: Learn here about getting started with Syncfusion Essential Studio WPF Split Button control, its elements and more.
-platform: wpf
+title: Getting Started with WPF Split Button control | Syncfusion®
+description: Learn here about getting started with Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
+platform: WPF
 control: SplitButtonAdv
 documentation: ug
 ---
@@ -53,7 +53,7 @@ In order to add the control manually in XAML, follow the below steps.
 
     * Syncfusion.Shared.WPF
 
-2. Import Syncfusion WPF schema `http://schemas.syncfusion.com/wpf` or the control namespace `Syncfusion.Windows.Tools.Controls` in XAML page.
+2. Import Syncfusion<sup>®</sup> WPF schema `http://schemas.syncfusion.com/wpf` or the control namespace `Syncfusion.Windows.Tools.Controls` in XAML page.
 
 3. Declare SplitButtonAdv control in XAML page.
 

--- a/wpf/Split-Button/Multiline-Text-Support.md
+++ b/wpf/Split-Button/Multiline-Text-Support.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Multiline Text in WPF Split Button control | Syncfusion
-description: Learn about Multiline Text support in Syncfusion Essential Studio WPF Split Button control, its elements and more.
-platform: wpf
+title: Multiline Text in WPF Split Button control | Syncfusion®
+description: Learn about Multiline Text support in Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
+platform: WPF
 control: SplitButtonAdv
 documentation: ug
 ---

--- a/wpf/Split-Button/Overview.md
+++ b/wpf/Split-Button/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Split Button control | Syncfusion
-description: Learn here all about introduction of Syncfusion Essential Studio WPF Split Button control, its elements and more.
-platform: wpf
+title: About WPF Split Button control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
+platform: WPF
 control: SplitButtonAdv
 documentation: ug
 ---

--- a/wpf/Split-Button/Styles-and-Templates.md
+++ b/wpf/Split-Button/Styles-and-Templates.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Styles and Templates in WPF Split Button control | Syncfusion
-description: Learn about Styles and Templates support in Syncfusion Essential Studio WPF Split Button control, its elements and more.
-platform: wpf
+title: Styles and Templates in WPF Split Button control | Syncfusion®
+description: Learn about Styles and Templates support in Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
+platform: WPF
 control: SplitButtonAdv
 documentation: ug
 ---

--- a/wpf/Split-Button/Themes.md
+++ b/wpf/Split-Button/Themes.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Themes in WPF Split Button control | Syncfusion
-description: Learn about Themes support in Syncfusion Essential Studio WPF Split Button control, its elements and more.
+title: Themes in WPF Split Button control | Syncfusion®
+description: Learn about Themes support in Syncfusion® Essential Studio® WPF Split Button control, its elements and more.
 platform: WPF
 control: SplitButtonAdv
 documentation: ug

--- a/wpf/TabControl/Appearance.md
+++ b/wpf/TabControl/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF TabControl control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: Appearance in WPF TabControl control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPF
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/TabControl/Arrange-tabs.md
+++ b/wpf/TabControl/Arrange-tabs.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Arrange tabs in WPF TabControl control | Syncfusion
-description: Learn here all about Arrange tabs support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: Arrange tabs in WPF TabControl control | Syncfusion®
+description: Learn here all about Arrange tabs support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPf
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/TabControl/Closable-tabs.md
+++ b/wpf/TabControl/Closable-tabs.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Close tabs in WPF TabControl control | Syncfusion
-description: Learn here all about Close tabs support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: Close tabs in WPF TabControl control | Syncfusion®
+description: Learn here all about Close tabs support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPF
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/TabControl/ContextMenu.md
+++ b/wpf/TabControl/ContextMenu.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Context menu in WPF TabControl control | Syncfusion
-description: Learn here all about Context menu support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: Context menu in WPF TabControl control | Syncfusion®
+description: Learn here all about Context menu support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPF
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/TabControl/DataBinding.md
+++ b/wpf/TabControl/DataBinding.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: DataBinding in WPF TabControl control | Syncfusion
-description: Learn here all about DataBinding support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: DataBinding in WPF TabControl control | Syncfusion®
+description: Learn here all about DataBinding support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPF
 control: TabControl
 documentation: ug
 ---

--- a/wpf/TabControl/Getting-Started.md
+++ b/wpf/TabControl/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF TabControl control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF TabControl (TabControlExt) control, its elements and more.
+title: Getting Started with WPF TabControl control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF TabControl (TabControlExt) control, its elements and more.
 platform: WPF
 control: TabControl
 documentation: ug
@@ -43,7 +43,7 @@ To add the `TabControl` manually in XAML, follow these steps:
     * Syncfusion.Tools.WPF
     * Syncfusion.Shared.WPF
 
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf**, and declare the `TabControl` in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf**, and declare the `TabControl` in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/TabControl/NewButton-Feature.md
+++ b/wpf/TabControl/NewButton-Feature.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: NewButton Feature in WPF TabControl control | Syncfusion
-description: Learn here all about NewButton Feature support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: NewButton Feature in WPF TabControl control | Syncfusion®
+description: Learn here all about NewButton Feature support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPF
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/TabControl/Overview.md
+++ b/wpf/TabControl/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF TabControl control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF TabControl (TabControlExt) control, its elements and more.
-platform: wpf
+title: About WPF TabControl control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF TabControl (TabControlExt) control, its elements and more.
+platform: WPF
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/TabControl/Pin-Unpin-tabs.md
+++ b/wpf/TabControl/Pin-Unpin-tabs.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Pin and Unpin TabItems in WPF TabControl control | Syncfusion
-description: Learn here all about Pin and Unpin TabItems support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: Pin and Unpin TabItems in WPF TabControl control | Syncfusion®
+description: Learn here all about Pin and Unpin TabItems support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPF
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/TabControl/Selecting-tabitem.md
+++ b/wpf/TabControl/Selecting-tabitem.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Select tab in WPF TabControl control | Syncfusion
-description: Learn here all about Select tab support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: Select tab in WPF TabControl control | Syncfusion®
+description: Learn here all about Select tab support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPF
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/TabControl/TabItem-Header.md
+++ b/wpf/TabControl/TabItem-Header.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: TabItem Header in WPF TabControl control | Syncfusion
-description: Learn here all about TabItem Header support in Syncfusion WPF TabControl (TabControlExt) control and more.
-platform: wpf
+title: TabItem Header in WPF TabControl control | Syncfusion®
+description: Learn here all about TabItem Header support in Syncfusion® WPF TabControl (TabControlExt) control and more.
+platform: WPF
 control: TabControlExt
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Adding-and-Removing-Items-from-the-Document-Container-Control.md
+++ b/wpf/Tabbed-MDI-Form/Adding-and-Removing-Items-from-the-Document-Container-Control.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Adding and Removing Items from the WPF Tabbed MDI Form | Syncfusion
-description: Learn here all about Adding and Removing Items from the Document Container Control support in Syncfusion WPF Tabbed MDI Form control and more.
-platform: wpf
+title: Adding and Removing Items from the WPF Tabbed MDI Form | Syncfusion®
+description: Learn here all about Adding and Removing Items from the Document Container Control support in Syncfusion® WPF Tabbed MDI Form control and more.
+platform: WPF
 control: Tabbed MDI Form
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Creating-Tab-Groups.md
+++ b/wpf/Tabbed-MDI-Form/Creating-Tab-Groups.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Creating Tab Groups in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about Creating Tab Groups support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Creating Tab Groups in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about Creating Tab Groups support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Disabling-Dragging-and-Dropping-of-TDI-Items-in-DockingManager-and-DocumentContainer.md
+++ b/wpf/Tabbed-MDI-Form/Disabling-Dragging-and-Dropping-of-TDI-Items-in-DockingManager-and-DocumentContainer.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Disabling Dragging and Dropping in WPF Tabbed MDI Form | Syncfusion
-description: Learn here all about Disabling Dragging and Dropping of TDI Items in Syncfusion WPF DockingManager and WPF Tabbed MDI Form (DocumentContainer).
-platform: wpf
+title: Disabling Dragging and Dropping in WPF Tabbed MDI Form | Syncfusion®
+description: Learn here all about Disabling Dragging and Dropping of TDI Items in Syncfusion® WPF DockingManager and WPF Tabbed MDI Form (DocumentContainer).
+platform: WPF
 control: Tabbed MDI Form
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Full-Screen-in-DocumentContainer.md
+++ b/wpf/Tabbed-MDI-Form/Full-Screen-in-DocumentContainer.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Full Screen in DocumentContainer in WPF Tabbed MDI Form | Syncfusion
-description: Learn here all about Full Screen in DocumentContainer support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Full Screen in DocumentContainer in WPF Tabbed MDI Form | Syncfusion®
+description: Learn here all about Full Screen in DocumentContainer support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: Tabbed MDI Form
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Getting-Started.md
+++ b/wpf/Tabbed-MDI-Form/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about getting started with Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Getting Started with WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about getting started with Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---
@@ -41,7 +41,7 @@ To add the control manually in XAML, follow the given steps:
 1. Add the following required assembly references to the project:
     * Syncfusion.Tools.WPF
     * Syncfusion.Shared.WPF 
-2. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
+2. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
 3. Declare the DocumentContainer control in the XAML page.
 
 {% capture codesnippet1 %}

--- a/wpf/Tabbed-MDI-Form/Layout-Related-Features.md
+++ b/wpf/Tabbed-MDI-Form/Layout-Related-Features.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Layout Related Features in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about Layout Related Features support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Layout Related Features in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about Layout Related Features support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Localization.md
+++ b/wpf/Tabbed-MDI-Form/Localization.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Localization in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about Localization support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Localization in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about Localization support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/MDI-Resize.md
+++ b/wpf/Tabbed-MDI-Form/MDI-Resize.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: MDI Resize in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about MDI Resize support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: MDI Resize in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about MDI Resize support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Maximizing-MDI-window.md
+++ b/wpf/Tabbed-MDI-Form/Maximizing-MDI-window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Maximizing MDI window in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about Maximizing MDI window support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Maximizing MDI window in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about Maximizing MDI window support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Minimizing-MDI-window.md
+++ b/wpf/Tabbed-MDI-Form/Minimizing-MDI-window.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Minimizing MDI window in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about Minimizing MDI window support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Minimizing MDI window in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about Minimizing MDI window support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Overview.md
+++ b/wpf/Tabbed-MDI-Form/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF Tabbed MDI Form (DocumentContainer) control, its elements and more.
-platform: wpf
+title: About WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control, its elements and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Pin-Unpin-tabs.md
+++ b/wpf/Tabbed-MDI-Form/Pin-Unpin-tabs.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Pin and Unpin TabItems in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about Pin and Unpin TabItems support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Pin and Unpin TabItems in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about Pin and Unpin TabItems support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Setting-Header-of-the-Document-container.md
+++ b/wpf/Tabbed-MDI-Form/Setting-Header-of-the-Document-container.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Setting Header of Document container in Tabbed MDI Form | Syncfusion
-description: Learn here all about Setting Header of the Document container support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Setting Header of Document container in Tabbed MDI Form | Syncfusion®
+description: Learn here all about Setting Header of the Document container support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: Tabbed MDI Form
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Setting-MDIBounds.md
+++ b/wpf/Tabbed-MDI-Form/Setting-MDIBounds.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Setting MDIBounds in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about Setting MDIBounds support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
+title: Setting MDIBounds in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about Setting MDIBounds support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
 platform: wpf
 control: DocumentContainer
 documentation: ug

--- a/wpf/Tabbed-MDI-Form/Setting-Mode-for-Document-Container.md
+++ b/wpf/Tabbed-MDI-Form/Setting-Mode-for-Document-Container.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: setting mode for document container in Tabbed MDI Form | Syncfusion
-description: Learn here all about setting mode for document container support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: setting mode for document container in Tabbed MDI Form | Syncfusion®
+description: Learn here all about setting mode for document container support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Setting-Window-State.md
+++ b/wpf/Tabbed-MDI-Form/Setting-Window-State.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Setting Window State in WPF Tabbed MDI Form | Syncfusion
-description: Learn here all about Setting Window State support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Setting Window State in WPF Tabbed MDI Form | Syncfusion®
+description: Learn here all about Setting Window State support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/Setting-Window-Switchers.md
+++ b/wpf/Tabbed-MDI-Form/Setting-Window-Switchers.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Setting Window Switchers in WPF Tabbed MDI Form | Syncfusion
-description: Learn here all about Setting Window Switchers support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: Setting Window Switchers in WPF Tabbed MDI Form | Syncfusion®
+description: Learn here all about Setting Window Switchers support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tabbed-MDI-Form/State-Persistence.md
+++ b/wpf/Tabbed-MDI-Form/State-Persistence.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: State Persistence in WPF Tabbed MDI Form control | Syncfusion
-description: Learn here all about State Persistence support in Syncfusion WPF Tabbed MDI Form (DocumentContainer) control and more.
-platform: wpf
+title: State Persistence in WPF Tabbed MDI Form control | Syncfusion®
+description: Learn here all about State Persistence support in Syncfusion® WPF Tabbed MDI Form (DocumentContainer) control and more.
+platform: WPF
 control: DocumentContainer
 documentation: ug
 ---

--- a/wpf/Tile-View/Appearance.md
+++ b/wpf/Tile-View/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF Tile View control | Syncfusion
-description: Learn about Appearance support in Syncfusion Essential Studio WPF TileView Control, its elements and more.
-platform: wpf
+title: Appearance in WPF Tile View control | Syncfusion®
+description: Learn about Appearance support in Syncfusion® Essential Studio® WPF TileView Control, its elements and more.
+platform: WPF
 control: TileViewControl
 documentation: ug
 ---

--- a/wpf/Tile-View/Arrange-TileViewItem.md
+++ b/wpf/Tile-View/Arrange-TileViewItem.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Arrange TileViewItem in WPF Tile View control | Syncfusion
-description: Learn about Arrange TileViewItem support in Syncfusion WPF Tile View control, its elements and more.
-platform: wpf
+title: Arrange TileViewItem in WPF Tile View control | Syncfusion®
+description: Learn about Arrange TileViewItem support in Syncfusion® WPF Tile View control, its elements and more.
+platform: WPF
 control: TileViewControl
 documentation: ug
 ---

--- a/wpf/Tile-View/BringIntoView.md
+++ b/wpf/Tile-View/BringIntoView.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: BringIntoView in WPF Tile View control | Syncfusion
-description: Learn about BringIntoView support in Syncfusion Essential Studio WPF Tile View control, its elements and more.
-platform: wpf
+title: BringIntoView in WPF Tile View control | Syncfusion®
+description: Learn about BringIntoView support in Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
+platform: WPF
 control: TileViewControl
 documentation: ug
 ---

--- a/wpf/Tile-View/Closable-TileViewItem.md
+++ b/wpf/Tile-View/Closable-TileViewItem.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Close TileViewItem in WPF Tile View control | Syncfusion
-description: Learn about Close TileViewItem support in Syncfusion Essential Studio WPF Tile View control, its elements and more.
-platform: wpf
+title: Close TileViewItem in WPF Tile View control | Syncfusion®
+description: Learn about Close TileViewItem support in Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
+platform: WPF
 control: TileViewControl
 documentation: ug
 ---

--- a/wpf/Tile-View/Data-Binding-Support.md
+++ b/wpf/Tile-View/Data-Binding-Support.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Data Binding in WPF Tile View control | Syncfusion
-description: Learn about Data Binding support in Syncfusion Essential Studio WPF Tile View control, its elements and more.
-platform: wpf
+title: Data Binding in WPF Tile View control | Syncfusion®
+description: Learn about Data Binding support in Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
+platform: WPF
 control: TileViewControl
 documentation: ug
 ---

--- a/wpf/Tile-View/Getting-Started.md
+++ b/wpf/Tile-View/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF Tile View control | Syncfusion
-description: Learn here about getting started with Syncfusion Essential Studio WPF Tile View control, its elements and more.
+title: Getting Started with WPF Tile View control | Syncfusion®
+description: Learn here about getting started with Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
 platform: WPF
 control: TileViewControl
 documentation: ug
@@ -41,7 +41,7 @@ To add the `TileViewControl` manually in XAML, follow these steps:
 
     * Syncfusion.Shared.WPF
 
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf**, and declare the `TileViewControl` in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf**, and declare the `TileViewControl` in XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}

--- a/wpf/Tile-View/How-To/Customize-Built-in-Animations.md
+++ b/wpf/Tile-View/How-To/Customize-Built-in-Animations.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Customize Built-in Animations | TileView | wpf | Syncfusion
-description: Customize built-in animations in Syncfusion Essential Studio WPF TileView Control, its elements and more.
-platform: wpf
+title: Customize Built-in Animations | TileView | wpf | Syncfusion®
+description: Customize built-in animations in Syncfusion® Essential Studio® WPF TileView Control, its elements and more.
+platform: WPF
 control: TileView Control
 documentation: ug
 ---

--- a/wpf/Tile-View/How-To/Enable-the-ClickHeaderToMaximize.md
+++ b/wpf/Tile-View/How-To/Enable-the-ClickHeaderToMaximize.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Enable the ClickHeaderToMaximize | TileView | wpf | Syncfusion
-description: Enable the clickheadertomaximize in Syncfusion Essential Studio WPF TileView Control, its elements and more.
-platform: wpf
+title: Enable the ClickHeaderToMaximize | TileView | wpf | Syncfusion®
+description: Enable the clickheadertomaximize in Syncfusion® Essential Studio® WPF TileView Control, its elements and more.
+platform: WPF
 control: TileView Control
 documentation: ug
 ---

--- a/wpf/Tile-View/How-To/Set-the-Visibility-of-the-CloseButton.md
+++ b/wpf/Tile-View/How-To/Set-the-Visibility-of-the-CloseButton.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Set the Visibility of the CloseButton | TileView | wpf | Syncfusion
-description: Set the visibility of the closebutton in Syncfusion Essential Studio WPF TileView Control, its elements and more.
-platform: wpf
+title: Set the Visibility of the CloseButton | TileView | wpf | Syncfusion®
+description: Set the visibility of the closebutton in Syncfusion® Essential Studio® WPF TileView Control, its elements and more.
+platform: WPF
 control: TileView Control
 documentation: ug
 ---

--- a/wpf/Tile-View/Maximize-TileViewItem.md
+++ b/wpf/Tile-View/Maximize-TileViewItem.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Maximize TileViewItem in WPF Tile View control | Syncfusion
-description: Learn about Maximize TileViewItem support in Syncfusion Essential Studio WPF Tile View control, its elements and more.
-platform: wpf
+title: Maximize TileViewItem in WPF Tile View control | Syncfusion®
+description: Learn about Maximize TileViewItem support in Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
+platform: WPF
 control: TileViewControl
 documentation: ug
 ---

--- a/wpf/Tile-View/Minimize-TileViewItem.md
+++ b/wpf/Tile-View/Minimize-TileViewItem.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Minimize TileViewItem in WPF Tile View control | Syncfusion
-description: Learn about Minimize TileViewItem support in Syncfusion Essential Studio WPF Tile View control, its elements and more.
-platform: wpf
+title: Minimize TileViewItem in WPF Tile View control | Syncfusion®
+description: Learn about Minimize TileViewItem support in Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
+platform: WPF
 control: TileViewControl
 documentation: ug
 ---

--- a/wpf/Tile-View/Overview.md
+++ b/wpf/Tile-View/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF Tile View control | Syncfusion
-description: Learn here all about introduction of Syncfusion Essential Studio WPF Tile View control, its elements and more.
-platform: wpf
+title: About WPF Tile View control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
+platform: WPF
 control: TileView Control
 documentation: ug
 ---

--- a/wpf/Tile-View/TileViewItem-Header.md
+++ b/wpf/Tile-View/TileViewItem-Header.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: TileViewItem Header in WPF Tile View control | Syncfusion
-description: Learn about TileViewItem Header support in Syncfusion Essential Studio WPF Tile View control, its elements and more.
-platform: wpf
+title: TileViewItem Header in WPF Tile View control | Syncfusion®
+description: Learn about TileViewItem Header support in Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
+platform: WPF
 control: TileViewControl
 documentation: ug
 ---

--- a/wpf/Tile-View/Working-with-TileView.md
+++ b/wpf/Tile-View/Working-with-TileView.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Working with TileView in WPF Tile View control | Syncfusion
-description: Learn about Working with TileView support in Syncfusion Essential Studio WPF Tile View control, its elements and more.
+title: Working with TileView in WPF Tile View control | Syncfusion®
+description: Learn about Working with TileView support in Syncfusion® Essential Studio® WPF Tile View control, its elements and more.
 platform: WPF
 control: TileViewControl
 documentation: ug

--- a/wpf/TimePicker/Appearance-and-Styling.md
+++ b/wpf/TimePicker/Appearance-and-Styling.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF TimePicker control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF TimePicker (SfTimePicker) control and more.
-platform: wpf
+title: Appearance in WPF TimePicker control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF TimePicker (SfTimePicker) control and more.
+platform: WPF
 control: SfTimePicker
 documentation: ug
 ---

--- a/wpf/TimePicker/Customizing-DropDown.md
+++ b/wpf/TimePicker/Customizing-DropDown.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Customizing DropDown in WPF TimePicker control | Syncfusion
-description: Learn here all about Customizing DropDown support in Syncfusion WPF TimePicker (SfTimePicker) control and more.
-platform: wpf
+title: Customizing DropDown in WPF TimePicker control | Syncfusion®
+description: Learn here all about Customizing DropDown support in Syncfusion® WPF TimePicker (SfTimePicker) control and more.
+platform: WPF
 control:  SfTimePicker
 documentation: ug
 ---

--- a/wpf/TimePicker/Formatting.md
+++ b/wpf/TimePicker/Formatting.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Time Formatting in WPF TimePicker control | Syncfusion
-description: Learn here all about Time Formatting support in Syncfusion WPF TimePicker (SfTimePicker) control and more.
-platform: wpf
+title: Time Formatting in WPF TimePicker control | Syncfusion®
+description: Learn here all about Time Formatting support in Syncfusion® WPF TimePicker (SfTimePicker) control and more.
+platform: WPF
 control: SfTimePicker
 documentation: ug
 ---

--- a/wpf/TimePicker/Getting-Started.md
+++ b/wpf/TimePicker/Getting-Started.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Getting Started with WPF TimePicker control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF TimePicker (SfTimePicker) control, its elements and more.
-platform: wpf
+title: Getting Started with WPF TimePicker control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF TimePicker (SfTimePicker) control, its elements and more.
+platform: WPF
 control: SfTimePicker
 documentation: ug
 ---
@@ -39,7 +39,7 @@ To add the control manually in XAML, follow the given steps:
 1. Add the following required assembly references to the project:
     * Syncfusion.SfInput.WPF
     * Syncfusion.SfShared.WPF
-2. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
+2. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** in the XAML page.
 3. Declare the `SfTimePicker` control in the XAML page.
 
 {% capture codesnippet1 %}

--- a/wpf/TimePicker/Overview.md
+++ b/wpf/TimePicker/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF TimePicker control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF TimePicker (SfTimePicker) control, its elements and more.
-platform: wpf
+title: About WPF TimePicker control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF TimePicker (SfTimePicker) control, its elements and more.
+platform: WPF
 control: SfTimePicker
 documentation: ug
 ---

--- a/wpf/TimePicker/Setting-Value.md
+++ b/wpf/TimePicker/Setting-Value.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Setting Time in WPF TimePicker control | Syncfusion
-description: Learn here all about Setting Time support in Syncfusion WPF TimePicker (SfTimePicker) control and more.
-platform: wpf
+title: Setting Time in WPF TimePicker control | Syncfusion®
+description: Learn here all about Setting Time support in Syncfusion® WPF TimePicker (SfTimePicker) control and more.
+platform: WPF
 control: SfTimePicker
 documentation: ug
 ---

--- a/wpf/TimePicker/SfTimeSelector.md
+++ b/wpf/TimePicker/SfTimeSelector.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Time Selector in WPF TimePicker control | Syncfusion
-description: Learn here all about Time Selector support in Syncfusion WPF TimePicker (SfTimePicker) control and more.
-platform: wpf
+title: Time Selector in WPF TimePicker control | Syncfusion®
+description: Learn here all about Time Selector support in Syncfusion® WPF TimePicker (SfTimePicker) control and more.
+platform: WPF
 control: SfTimePicker
 documentation: ug
 ---

--- a/wpf/TimeSpan-Editor/Appearance.md
+++ b/wpf/TimeSpan-Editor/Appearance.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Appearance in WPF TimeSpan Editor control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion WPF TimeSpan Editor (TimeSpanEdit) control and more.
-platform: wpf
+title: Appearance in WPF TimeSpan Editor control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® WPF TimeSpan Editor (TimeSpanEdit) control and more.
+platform: WPF
 control: TimeSpanEdit
 documentation: ug
 ---

--- a/wpf/TimeSpan-Editor/Getting-Started.md
+++ b/wpf/TimeSpan-Editor/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with WPF TimeSpan Editor control | Syncfusion
-description: Learn here about getting started with Syncfusion WPF TimeSpan Editor (TimeSpanEdit) control, its elements and more.
+title: Getting Started with WPF TimeSpan Editor control | Syncfusion®
+description: Learn here about getting started with Syncfusion® WPF TimeSpan Editor (TimeSpanEdit) control, its elements and more.
 platform: WPF
 control: TimeSpanEdit
 documentation: ug
@@ -39,7 +39,7 @@ To add the `TimeSpanEdit` control manually in XAML, follow these steps:
 2. Add the  following assembly references to the project,
     * Syncfusion.Shared.WPF
  
-3. Import Syncfusion WPF schema **http://schemas.syncfusion.com/wpf** and declare the `TimeSpanEdit` control in XAML page.
+3. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** and declare the `TimeSpanEdit` control in XAML page.
 
 4. Declare the `TimeSpanEdit` control in XAML page.
 

--- a/wpf/TimeSpan-Editor/Overview.md
+++ b/wpf/TimeSpan-Editor/Overview.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: About WPF TimeSpan Editor control | Syncfusion
-description: Learn here all about introduction of Syncfusion WPF TimeSpan Editor (TimeSpanEdit) control, its elements and more.
-platform: wpf
+title: About WPF TimeSpan Editor control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® WPF TimeSpan Editor (TimeSpanEdit) control, its elements and more.
+platform: WPF
 control: TimeSpanEdit
 documentation: ug
 ---

--- a/wpf/TimeSpan-Editor/Working-with-TimeSpanEdit.md
+++ b/wpf/TimeSpan-Editor/Working-with-TimeSpanEdit.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Working with TimeSpanEdit in WPF TimeSpan Editor control | Syncfusion
-description: Learn here all about Working with TimeSpanEdit support in Syncfusion WPF TimeSpan Editor (TimeSpanEdit) control and more.
+title: Working with TimeSpanEdit in WPF TimeSpan Editor control | Syncfusion®
+description: Learn here all about Working with TimeSpanEdit support in Syncfusion® WPF TimeSpan Editor (TimeSpanEdit) control and more.
 platform: WPF
 control: TimeSpanEdit
 documentation: ug


### PR DESCRIPTION
### Task

[UG documentation 940787](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/940787): Include Registered Trademark symbol for all of our tool's controls in WPF, UWP UG

### Task Description
I have included the trademark symbol for Syncfusion , Essential and Essential Studio for the following 

Calenderedit
Carousel
Checklistbox
Currency textbox
Dockingmanager
DocumentContainer
DoubleTextbox
IntegerTextBox
MaskedTextBox
PercentTextBox
PinnablelTextBox
Ribbon
SfBadge
SfCalculator
SfColorpalette
SfDatePicker
DomainUpdown
SfGridSplitter
SfMaskEdit
SfSpellChecker
ColorPickerPalette
ColorPicker
SfUpDown
UpDown
PinnableListBox
TimePicker
SplitButton
TileViewControl
TimeSpanEdit
TabControlExt


**Note:** We have updated the registered symbol directly in the title and description because using the **sup** tag in a title shows the same text in the URL description.
![image](https://github.com/user-attachments/assets/8ec5d18a-532d-41f6-81a0-4c4687a2e7a3)

**Reference PR :** https://github.com/syncfusion-content/maui-docs/pull/2980/files

### Related PR
https://github.com/syncfusion-content/windowsforms-docs/pull/1141