### PR TITLE
WPF- 931860 : Marked the NotifyIcon as Classic control hotfix

### DIFF
--- a/wpf-toc.html
+++ b/wpf-toc.html
@@ -2309,10 +2309,10 @@
     <li>
         NotifyIcon (Classic)
         <ul>
-            <li><a href="/wpf/Notify-Icon/overview">Overview</a></li>
-            <li><a href="/wpf/Notify-Icon/getting-started">Getting Started</a></li>
-            <li><a href="/wpf/Notify-Icon/interactive-features">Interactive Features</a></li>
-            <li><a href="/wpf/Notify-Icon/layout-related-features">Layout Related Features</a></li>
+            <li><a href="/wpf/classic/Notify-Icon/overview">Overview</a></li>
+            <li><a href="/wpf/classic/Notify-Icon/getting-started">Getting Started</a></li>
+            <li><a href="/wpf/classic/Notify-Icon/interactive-features">Interactive Features</a></li>
+            <li><a href="/wpf/classic/Notify-Icon/layout-related-features">Layout Related Features</a></li>
         </ul>
     </li>
     <li>

--- a/wpf-toc.html
+++ b/wpf-toc.html
@@ -1322,15 +1322,6 @@
         </ul>
     </li>
     <li>
-        NotifyIcon
-        <ul>
-            <li><a href="/wpf/Notify-Icon/overview">Overview</a></li>
-            <li><a href="/wpf/Notify-Icon/getting-started">Getting Started</a></li>
-            <li><a href="/wpf/Notify-Icon/interactive-features">Interactive Features</a></li>
-            <li><a href="/wpf/Notify-Icon/layout-related-features">Layout Related Features</a></li>
-        </ul>
-    </li>
-    <li>
         OlapChart
         <ul>
             <li><a href="/wpf/Olap-Chart/overview">Overview</a></li>
@@ -2313,6 +2304,15 @@
             <li><a href="/wpf/classic/gridtree/data-population">Data Population</a></li>
             <li><a href="/wpf/classic/gridtree/columns">Columns</a></li>
             <li><a href="/wpf/classic/gridtree/interactive-features">Interactive Features</a></li>
+        </ul>
+    </li>
+    <li>
+        NotifyIcon (Classic)
+        <ul>
+            <li><a href="/wpf/Notify-Icon/overview">Overview</a></li>
+            <li><a href="/wpf/Notify-Icon/getting-started">Getting Started</a></li>
+            <li><a href="/wpf/Notify-Icon/interactive-features">Interactive Features</a></li>
+            <li><a href="/wpf/Notify-Icon/layout-related-features">Layout Related Features</a></li>
         </ul>
     </li>
     <li>


### PR DESCRIPTION
### Description:
Marked the NotifyIcon control as Classic control.