### PR TITLE
SEO-199937--WPF-Classic--Missing-H1

### DIFF
--- a/wpf/Classic/Chart/How-to/Bind-Data-Using-Data-Context.md
+++ b/wpf/Classic/Chart/How-to/Bind-Data-Using-Data-Context.md
@@ -7,7 +7,7 @@ control: Chart (Classic)
 documentation: ug
 ---
 
-## Bind Data Using Data Context
+# Bind Data Using Data Context
 
 When using multiple series' in the Chart, it might be convenient to set the Data Contexts at the Chart or Chart Area levels and refer to that context from the Chart Series.
 {% highlight xaml %}

--- a/wpf/Release-notes/Migratingtov16.1.0.24.md
+++ b/wpf/Release-notes/Migratingtov16.1.0.24.md
@@ -1,11 +1,11 @@
 ---
-title: Essential Studio for WPF 2018 volume 1 Migration document
-description: Essential Studio for WPF 2018 volume 1 Migration document
+title: Essential Studio for WPF 2018 Volume 1 Migration Info | Syncfusion
+description: This page provides information about using the WPF SfRichTextBoxAdv component in Essential Studio 2018 Volume 1.
 platform: wpf
 documentation: ug
 keywords: migration, upgrade-changes, 2018vol1-changes
 ---
-# SfRichTextBoxAdv
+# How to use SFRichTextBoxAdv in 16.1.024 compared to prior versions
 
 The SfRichTextBoxAdv control validates DocumentAdv instance internally when the value of Document property is updated. It ensures that minimal child elements are available in each container elements like,
 

--- a/wpf/Release-notes/Migratingtov16.1.0.24.md
+++ b/wpf/Release-notes/Migratingtov16.1.0.24.md
@@ -1,11 +1,11 @@
 ---
-title: Essential Studio for WPF 2018 Volume 1 Migration Info | Syncfusion
-description: This page provides information about using the WPF SfRichTextBoxAdv component in Essential Studio 2018 Volume 1.
+title: Essential Studio for WPF 2018 volume 1 Migration document
+description: Essential Studio for WPF 2018 volume 1 Migration document
 platform: wpf
 documentation: ug
 keywords: migration, upgrade-changes, 2018vol1-changes
 ---
-# How to use SFRichTextBoxAdv in 16.1.024 compared to prior versions
+# SfRichTextBoxAdv
 
 The SfRichTextBoxAdv control validates DocumentAdv instance internally when the value of Document property is updated. It ensures that minimal child elements are available in each container elements like,
 

--- a/wpf/Release-notes/Migratingtov16.1.0.24.md
+++ b/wpf/Release-notes/Migratingtov16.1.0.24.md
@@ -5,7 +5,7 @@ platform: wpf
 documentation: ug
 keywords: migration, upgrade-changes, 2018vol1-changes
 ---
-## SfRichTextBoxAdv
+# SfRichTextBoxAdv
 
 The SfRichTextBoxAdv control validates DocumentAdv instance internally when the value of Document property is updated. It ensures that minimal child elements are available in each container elements like,
 

--- a/wpf/Release-notes/Migratingtov16.1.0.24.md
+++ b/wpf/Release-notes/Migratingtov16.1.0.24.md
@@ -1,11 +1,11 @@
 ---
-title: Essential Studio for WPF 2018 volume 1 Migration document
-description: Essential Studio for WPF 2018 volume 1 Migration document
+title: Essential Studio for WPF 2018 Volume 1 Migration Info | Syncfusion
+description: This page explains the differences between using the WPF SfRichTextBoxAdv component in Essential Studio 2018 Volume 1 and prior versions.
 platform: wpf
 documentation: ug
 keywords: migration, upgrade-changes, 2018vol1-changes
 ---
-# SfRichTextBoxAdv
+# How to use SFRichTextBoxAdv in 16.1.024 compared to prior versions
 
 The SfRichTextBoxAdv control validates DocumentAdv instance internally when the value of Document property is updated. It ensures that minimal child elements are available in each container elements like,
 


### PR DESCRIPTION
Title | Description
-- | --
|Task Category | Site Audit Work- Missing H1|
|Content Task Link/Mail Screenshot |NA|
|Hotfix | https://github.com/syncfusion-content/wpf-docs/pull/1737|
|Ticket/Task link | https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/199937|
|Work link | https://syncfusion.sharepoint.com/:x:/r/sites/GH/_layouts/15/Doc.aspx?sourcedoc=%7B3cf1c3df-fa53-4ea4-8f74-28a05da09714%7D&action=edit&wdinitialsession=e033b7e1-ee0e-17dc-9ccc-7e31c7f249a2&wdrldsc=2&wdrldc=1&wdrldr=ReloadInEditMode%2CTransitionNonMetro%2COnSaveAsWebMet|

Changes Made | Reason for change |
|-- | -- |
| Worked on Missing | In SEO a page should have one H1 title|
|![image](https://github.com/user-attachments/assets/460a03ec-ed1c-41e5-a4c3-f5de6c085023)|Title should contain 70 character count|
|![image](https://github.com/user-attachments/assets/4641d50d-a495-497d-a23e-547d44301987)| H1 should contain 70 character count|
|![image](https://github.com/user-attachments/assets/71aad0e5-aa57-4749-84ab-f484d9905d25)| Description should contain 170 character count|