### PR TITLE
SEO-204825-Wpf-Duplicate-Description-Hotfix

### DIFF
--- a/wpf/Charts/Getting-Started.md
+++ b/wpf/Charts/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Getting Started with WPF Charts control | Syncfusion
-description: Learn here about getting started with Syncfusion® WPF Charts (SfChart) control, its elements and more.
+description: Learn here all about getting started with Syncfusion® WPF Charts (SfChart) control, its elements and more.
 platform: wpf
 control: SfChart
 documentation: ug

--- a/wpf/DataGrid/Conditional-Styling.md
+++ b/wpf/DataGrid/Conditional-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Conditional Styling in WPF DataGrid control | Syncfusion®
-description: Learn here all about Conditional Styling support in Syncfusion® WPF DataGrid (SfDataGrid) control and more.
+description: Check out and learn here all about Conditional Styling support in Syncfusion® WPF DataGrid (SfDataGrid) control and more.
 platform: wpf
 control: SfDataGrid
 documentation: ug

--- a/wpf/DataGrid/Data-Manipulation.md
+++ b/wpf/DataGrid/Data-Manipulation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: CRUD Operations in WPF DataGrid control | Syncfusion®
-description: Learn here all about CRUD Operations support in Syncfusion® WPF DataGrid (SfDataGrid) control and more.
+description: Check out and learn here all about CRUD Operations support in Syncfusion® WPF DataGrid (SfDataGrid) control and more.
 platform: wpf
 control: SfDataGrid
 documentation: ug

--- a/wpf/DataGrid/Filtering.md
+++ b/wpf/DataGrid/Filtering.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Filtering in WPF DataGrid control | Syncfusion®
-description: Learn here all about Filtering support in Syncfusion® WPF DataGrid (SfDataGrid) control, its elements and more details.
+description: Check out and learn here all about Filtering support in Syncfusion® WPF DataGrid (SfDataGrid) control, its elements and more details.
 platform: wpf
 control: SfDataGrid
 documentation: ug

--- a/wpf/DataGrid/Getting-Started.md
+++ b/wpf/DataGrid/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Getting Started with WPF DataGrid control | Syncfusion®
-description: Learn here about getting started with Syncfusion® WPF DataGrid (SfDataGrid) control, its elements and more.
+description: Learn here all about getting started with Syncfusion® WPF DataGrid (SfDataGrid) control, its elements and more.
 platform: wpf
 control: SfDataGrid
 documentation: ug

--- a/wpf/DataGrid/Rows.md
+++ b/wpf/DataGrid/Rows.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Rows in WPF DataGrid control | Syncfusion®
-description: Learn here all about Rows support in Syncfusion® WPF DataGrid (SfDataGrid) control, its elements and more details.
+description: Check out and learn here all about Rows support in Syncfusion® WPF DataGrid (SfDataGrid) control, its elements and more details.
 platform: wpf
 control: SfDataGrid
 documentation: ug

--- a/wpf/DataGrid/context-menu.md
+++ b/wpf/DataGrid/context-menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Context menu in WPF DataGrid control | Syncfusion®
-description: Learn here all about Context menu support in Syncfusion® WPF DataGrid (SfDataGrid) control, its elements and more details.
+description: Check out and learn here all about Context menu support in Syncfusion® WPF DataGrid (SfDataGrid) control, its elements and more details.
 platform: wpf
 control: SfDataGrid
 documentation: ug

--- a/wpf/Licensing/overview.md
+++ b/wpf/Licensing/overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Overview of Syncfusion license and unlock keys - Syncfusion
-description: Learn here about the Syncfusion license and unlock keys and difference between license and unlock keys.
+description: Learn here all about the Syncfusion license and unlock keys and difference between license and unlock keys.
 platform: WPF
 control: Essential Studio
 documentation: ug

--- a/wpf/Pdf-Viewer/Getting-Started.md
+++ b/wpf/Pdf-Viewer/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Getting Started with WPF Pdf Viewer control | Syncfusion&reg;
-description: Learn here about getting started with Syncfusion<sup>&reg;</sup>; Essential Studio&reg; WPF Pdf Viewer control, its elements and more.
+description: Learn here all about getting started with Syncfusion<sup>&reg;</sup>; Essential Studio&reg; WPF Pdf Viewer control, its elements and more.
 platform: wpf
 control: PDF Viewer
 documentation: ug

--- a/wpf/Themes/Skin-Manager.md
+++ b/wpf/Themes/Skin-Manager.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: WPF Skin Manager | Apply Themes for Syncfusion WPF controls
-description: Learn about how to apply the themes for Syncfusion WPF controls and Framework controls using the skin manager.
+description: Check out and learn about how to apply the themes for Syncfusion WPF controls and Framework controls using the skin manager.
 platform: wpf
 control: Themes
 documentation: ug


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Duplicate description|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Meta description| SEO rules say not to use the same description on multiple pages, so I changed it.|



Regards, 
Asha