### PR TITLE
Task(216023)-SEO-Bing-Reports-Help-Domain-Title-tag-has-additional-ta…

### DIFF
--- a/wpf/Step-ProgressBar/Data-Binding.md
+++ b/wpf/Step-ProgressBar/Data-Binding.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Data Binding in WPF Step ProgressBar control | Syncfusion<sup>&reg;</sup>;
+title: Data Binding in WPF Step ProgressBar control | Syncfusion
 description: Learn here all about Data Binding support in Syncfusion<sup>&reg;</sup>; WPF Step ProgressBar (SfStepProgressBar) control and more.
 platform: wpf
 control: Step ProgressBar

--- a/wpf/Step-ProgressBar/Getting-Started.md
+++ b/wpf/Step-ProgressBar/Getting-Started.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Getting Started with WPF Step ProgressBar control | Syncfusion<sup>&reg;</sup>;
+title: Getting Started with WPF Step ProgressBar control | Syncfusion
 description: Learn here about getting started with Syncfusion<sup>&reg;</sup>; WPF Step ProgressBar (SfStepProgressBar) control, its elements and more.
 platform: wpf
 control: SfStepProgressBar

--- a/wpf/Step-ProgressBar/Overview.md
+++ b/wpf/Step-ProgressBar/Overview.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: About WPF Step ProgressBar control | Syncfusion<sup>&reg;</sup>;
+title: About WPF Step ProgressBar control | Syncfusion
 description: Learn here all about introduction of Syncfusion<sup>&reg;</sup>; WPF Step ProgressBar (SfStepProgressBar) control, its elements and more.
 platform: WPF
 control: SfStepProgressBar


### PR DESCRIPTION
 Hi @AishwaryaGanesan 

|Title|Description|
|--|--|
|Task Category| Bing Reports - Title contains addititonal Tag
|Content Task Link/Mail Screenshot|NA|
|UX task| NA|
|Hotfix|https://github.com/syncfusion-content/wpf-docs/pull/2088|
|Ticket/Task link|https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/216023/
|Excel/SharePoint 



|Changes made|Reason for changes|
|--|--|
|Title contains additional tag|Removed the additional tag as per the management concern|

Regards,
Mercy A.