### PR TITLE
Bug 1018253: Argument Exception thrown while sorting GridHyperLinkColumn when property type is Uri

### DIFF
--- a/wpf/DataGrid/Sorting.md
+++ b/wpf/DataGrid/Sorting.md
@@ -51,6 +51,8 @@ N> The [GridColumn.AllowSorting](https://help.syncfusion.com/cr/wpf/Syncfusion.U
 
 End users can sort the column by clicking column header cell. Once the columns get sorted, the sort indicator will be displayed on the right side of the column header.
 
+N> Sorting is not supported for `GridHyperLinkColumn` when the bound property type is `Uri`, since [`System.Uri`](https://learn.microsoft.com/dotnet/api/system.uri) does not implement [`IComparable`](https://learn.microsoft.com/dotnet/api/system.icomparable). If sorting is required, a custom comparison logic based on a comparable value should be used.
+
 ![Sorting in WPF DataGrid](Sorting_images/wpf-datagrid-sorting.png)
 
 

--- a/wpf/DataGrid/Sorting.md
+++ b/wpf/DataGrid/Sorting.md
@@ -51,7 +51,7 @@ N> The [GridColumn.AllowSorting](https://help.syncfusion.com/cr/wpf/Syncfusion.U
 
 End users can sort the column by clicking column header cell. Once the columns get sorted, the sort indicator will be displayed on the right side of the column header.
 
-N> Sorting is not supported for `GridHyperLinkColumn` when the bound property type is `Uri`, since [`System.Uri`](https://learn.microsoft.com/dotnet/api/system.uri) does not implement [`IComparable`](https://learn.microsoft.com/dotnet/api/system.icomparable). If sorting is required, a custom comparison logic based on a comparable value should be used.
+N> Sorting is not supported for `GridHyperLinkColumn` when the bound property type is `Uri`, since [`System.Uri`](https://learn.microsoft.com/en-us/dotnet/api/system.uri?view=net-10.0) does not implement [`IComparable`](https://learn.microsoft.com/en-us/dotnet/api/system.icomparable?view=net-10.0). If sorting is required, a custom comparison logic based on a comparable value should be used.
 
 ![Sorting in WPF DataGrid](Sorting_images/wpf-datagrid-sorting.png)
 


### PR DESCRIPTION
## Description

This PR updates the `sorting.md` documentation under SfDataGrid to clearly document a known limitation with URI-based sorting.

A note has been added explaining that when GridHyperlinkColumn is bound to a URI value, the default comparison logic does not support proper sorting because Uri does not implement IComparable. As a result, sorting behavior may not work as expected in this scenario.

### Changes Made

Added a documentation note in sfdatagrid/sorting.md describing the sorting limitation for GridHyperlinkColumn with URI values.

Task link - [Bug 1018253](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/1018253): Argument Exception thrown while sorting GridHyperLinkColumn when property type is Uri