### PR TITLE
WPF-883306: Add the Limitation for the Checkbox Recursive Mode

### DIFF
--- a/wpf/TreeView/Checkbox.md
+++ b/wpf/TreeView/Checkbox.md
@@ -251,7 +251,7 @@ sfTreeView.CheckedItems.Add(viewModel.Items[3]);
 {% endhighlight %}
 {% endtabs %}
 
-N> Set [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) as `Instant` when programmatically adding items to the [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) to enable the `Recursive` checkbox mode.
+N> To ensure correct `Recursive` checkbox behavior when updating [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) programmatically, set [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) to `Instant`.
 
 ## Events
 

--- a/wpf/TreeView/Checkbox.md
+++ b/wpf/TreeView/Checkbox.md
@@ -274,3 +274,8 @@ private void SfTreeView_NodeChecked(object sender, NodeCheckedEventArgs e)
 {% endtabs %}
 
 N> `NodeChecked` event occurs only in UI interactions. You can refer to our [WPF TreeView](https://www.syncfusion.com/wpf-controls/treeview) feature tour page for its groundbreaking feature representations. You can also explore our [WPF TreeView example](https://github.com/syncfusion/wpf-demos) to knows how to represents hierarchical data in a tree-like structure with expand and collapse node options.
+
+### Limitations
+
+   * When [CheckBoxMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckBoxMode) is `Recursive` and [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) is `OnDemand`(default), programmatically adding items to the [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) collection does not correctly update parent checkbox states (checked, unchecked, or intermediate).
+   * In `OnDemand` mode, child nodes are created only when their parent nodes are expanded. As a result, for items under collapsed parents, the control cannot locate the corresponding [TreeViewNode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.Engine.TreeViewNode.html), which prevents `Recursive` checkbox state propagation to parent nodes.

--- a/wpf/TreeView/Checkbox.md
+++ b/wpf/TreeView/Checkbox.md
@@ -251,6 +251,8 @@ sfTreeView.CheckedItems.Add(viewModel.Items[3]);
 {% endhighlight %}
 {% endtabs %}
 
+N> Set [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) as `Instant` when programmatically adding items to the [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) to enable the `Recursive` checkbox mode.
+
 ## Events
 
 ### NodeChecked event

--- a/wpf/TreeView/Data-Population.md
+++ b/wpf/TreeView/Data-Population.md
@@ -25,16 +25,10 @@ To update the collection changes in UI, it is necessary to define [NotificationS
    * None - It is a default mode and it doesn’t reflect collection/property changes in UI.
 To decide how to populate the nodes, it is necessary to set this `NodePopulationMode` API to Treeview.
 
-### NodePopulationMode
 The [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) API has following enum values:
 
    * OnDemand - Populate the child nodes only when parent nodes is expanded. It is the default value.
    * Instant - Populates all the child nodes when Treeview control is initially loaded.
-
-### Limitations
-
-   * When [CheckBoxMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckBoxMode) is `Recursive` and [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) is `OnDemand`(default), programmatically adding items to the [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) collection does not correctly update parent checkbox states (checked, unchecked, or intermediate).
-   * In `OnDemand` mode, child nodes are created only when their parent nodes are expanded. As a result, for items under collapsed parents, the control cannot locate the corresponding [TreeViewNode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.Engine.TreeViewNode.html), which prevents `Recursive` checkbox state propagation to parent nodes.
     
 ### Create Data Model for treeview
 

--- a/wpf/TreeView/Data-Population.md
+++ b/wpf/TreeView/Data-Population.md
@@ -31,7 +31,7 @@ The [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.T
    * OnDemand - Populate the child nodes only when parent nodes is expanded. It is the default value.
    * Instant - Populates all the child nodes when Treeview control is initially loaded.
 
-### Limitations when CheckBoxMode is Recursive
+### Limitations
 
    * When [CheckBoxMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckBoxMode) is `Recursive` and [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) is `OnDemand`(default), programmatically adding items to the [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) collection does not correctly update parent checkbox states (checked, unchecked, or intermediate).
    * In `OnDemand` mode, child nodes are created only when their parent nodes are expanded. As a result, for items under collapsed parents, the control cannot locate the corresponding [TreeViewNode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.Engine.TreeViewNode.html), which prevents `Recursive` checkbox state propagation to parent nodes.

--- a/wpf/TreeView/Data-Population.md
+++ b/wpf/TreeView/Data-Population.md
@@ -29,7 +29,6 @@ The [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.T
 
    * OnDemand - Populate the child nodes only when parent nodes is expanded. It is the default value.
    * Instant - Populates all the child nodes when Treeview control is initially loaded.
-    
 ### Create Data Model for treeview
 
 Create a simple data source as shown in the following code example in a new class file, and save it as FileManager.cs file:

--- a/wpf/TreeView/Data-Population.md
+++ b/wpf/TreeView/Data-Population.md
@@ -29,6 +29,7 @@ The [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.T
 
    * OnDemand - Populate the child nodes only when parent nodes is expanded. It is the default value.
    * Instant - Populates all the child nodes when Treeview control is initially loaded.
+   
 ### Create Data Model for treeview
 
 Create a simple data source as shown in the following code example in a new class file, and save it as FileManager.cs file:

--- a/wpf/TreeView/Data-Population.md
+++ b/wpf/TreeView/Data-Population.md
@@ -26,7 +26,6 @@ To update the collection changes in UI, it is necessary to define [NotificationS
 To decide how to populate the nodes, it is necessary to set this `NodePopulationMode` API to Treeview.
 
 ### NodePopulationMode
-
 The [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) API has following enum values:
 
    * OnDemand - Populate the child nodes only when parent nodes is expanded. It is the default value.
@@ -34,8 +33,9 @@ The [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.T
 
 ### Limitations when CheckBoxMode is Recursive
 
-When [CheckBoxMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckBoxMode) is set to `Recursive` and [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) is set to `OnDemand` (default), programmatically adding items to the [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) collection will not correctly update parent checkbox states (tri-state: intermediate/checked/unchecked). This is because child nodes are not created until parent nodes are expanded, so the control cannot locate the [TreeViewNode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.Engine.TreeViewNode.html) to propagate the checkbox state. To use recursive checkbox propagation correctly, `NodePopulationMode` must be set to `Instant`. 
-
+   * When [CheckBoxMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckBoxMode) is `Recursive` and [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) is `OnDemand`(default), programmatically adding items to the [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) collection does not correctly update parent checkbox states (checked, unchecked, or intermediate).
+   * In `OnDemand` mode, child nodes are created only when their parent nodes are expanded. As a result, for items under collapsed parents, the control cannot locate the corresponding [TreeViewNode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.Engine.TreeViewNode.html), which prevents `Recursive` checkbox state propagation to parent nodes.
+    
 ### Create Data Model for treeview
 
 Create a simple data source as shown in the following code example in a new class file, and save it as FileManager.cs file:

--- a/wpf/TreeView/Data-Population.md
+++ b/wpf/TreeView/Data-Population.md
@@ -25,10 +25,16 @@ To update the collection changes in UI, it is necessary to define [NotificationS
    * None - It is a default mode and it doesn’t reflect collection/property changes in UI.
 To decide how to populate the nodes, it is necessary to set this `NodePopulationMode` API to Treeview.
 
+### NodePopulationMode
+
 The [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) API has following enum values:
 
    * OnDemand - Populate the child nodes only when parent nodes is expanded. It is the default value.
    * Instant - Populates all the child nodes when Treeview control is initially loaded.
+
+### Limitations when CheckBoxMode is Recursive
+
+When [CheckBoxMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckBoxMode) is set to `Recursive` and [NodePopulationMode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_NodePopulationMode) is set to `OnDemand` (default), programmatically adding items to the [CheckedItems](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.SfTreeView.html#Syncfusion_UI_Xaml_TreeView_SfTreeView_CheckedItems) collection will not correctly update parent checkbox states (tri-state: intermediate/checked/unchecked). This is because child nodes are not created until parent nodes are expanded, so the control cannot locate the [TreeViewNode](https://help.syncfusion.com/cr/wpf/Syncfusion.UI.Xaml.TreeView.Engine.TreeViewNode.html) to propagate the checkbox state. To use recursive checkbox propagation correctly, `NodePopulationMode` must be set to `Instant`. 
 
 ### Create Data Model for treeview
 


### PR DESCRIPTION
### Task:
[Task_883306](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/883306/): Add the Limitation for the Checkbox Recursive Mode

### Description:
Added a limitation for scenarios where items are programmatically added to CheckedItems, to ensure the recursive checkbox mode updates parent states correctly.
