### PR TITLE
WPF-1034257 - Need to revert the Canonical links from the WPF diagram_hotfix

### DIFF
--- a/wpf/Diagram/Getting-Started.md
+++ b/wpf/Diagram/Getting-Started.md
@@ -5,7 +5,6 @@ description: Learn here about getting started with Syncfusion® WPF Diagram (SfD
 platform: wpf
 control: SfDiagram
 documentation: ug
-canonical_url: "https://www.syncfusion.com/wpf-controls/diagram"
 ---
 
 # Getting Started with WPF Diagram (SfDiagram)

--- a/wpf/Diagram/Overview.md
+++ b/wpf/Diagram/Overview.md
@@ -5,7 +5,6 @@ description: Learn here all about introduction of Syncfusion® WPF Diagram (SfDi
 platform: wpf
 control: SfDiagram
 documentation: ug
-canonical_url: "https://www.syncfusion.com/wpf-controls/diagram"
 ---
 
 # WPF Diagram (SfDiagram) Overview


### PR DESCRIPTION
Need to revert the Canonical links from the WPF diagram