### PR TITLE
Task(SEO-222716) WPF Scheduler Eval Plan Documentation UG Interlinking

### DIFF
--- a/wpf/Scheduler/Overview.md
+++ b/wpf/Scheduler/Overview.md
@@ -47,4 +47,4 @@ The [WPF Scheduler](https://www.syncfusion.com/wpf-controls/scheduler) control i
 **LoadOnDemand** - The SfScheduler supports loading appointments on-demand with loading indicator and it improves the loading performance when there are appointments range for multiple years.
 
 
-N> You can also explore our [WPF Scheduler example](https://github.com/syncfusion/wpf-demos) to knows how to schedule and manage appointments through an intuitive user interface, similar to the Outlook calendar.
+N> You can also explore our [WPF Scheduler example](https://github.com/syncfusion/wpf-demos) to knows how to schedule and manage appointments through an intuitive user interface, similar to the Outlook calendar. Looking for the full WPF Scheduler component overview, features, pricing, and documentation? Visit the [WPF Scheduler](https://www.syncfusion.com/wpf-controls/scheduler) page.


### PR DESCRIPTION
Modifying interlinking text
Change all interlinking of Syncfusion Wpf Scheduler to Wpf Scheduler in all the documentation pages
Adding NOTES section in getting started page
Additional Note in the bottom of the demos and documentation pages.
Looking for the full Angular Data Grid component overview, features, pricing, and documentation? Visit the Angular Data Grid page.

Hotfix PR - [https://github.com/syncfusion-content/wpf-docs/pull/2283](https://github.com/syncfusion-content/wpf-docs/pull/2283)