### PR TITLE
Documentation(1046078): Fix the getting started documentation issue for tools controls in WPF platform(Rating,TileControl)

### DIFF
--- a/wpf/Rating/Getting-Started.md
+++ b/wpf/Rating/Getting-Started.md
@@ -16,51 +16,58 @@ This section explains how to configure the [SfRating](https://help.syncfusion.co
 Refer to the [control dependencies](https://help.syncfusion.com/wpf/control-dependencies#sfrating) section to get the list of assemblies or NuGet package that needs to be added as a reference to use the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control in any application.
 
 You can find more details about installing the NuGet package in a WPF application in the following link:
-[How to install nuget packages](https://help.syncfusion.com/wpf/visual-studio-integration/nuget-packages)
+[How to install nuget packages](https://help.syncfusion.com/wpf/installation/install-nuget-packages)
 
 ## Creating Application with SfRating control
-In this walk through, user will create a WPF application that contains [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
-1. [Creating project](#creating-project)
-2. [Adding control via designer](#adding-control-via-designer)
-3. [Adding control manually in XAML](#adding-control-manually-in-xaml)
-4. [Adding control manually in C#](#add-control-manually-in-c)
+In this walkthrough, you will create a WPF application that contains the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
+1. [Creating the project](#creating-the-project)
+2. [Adding the control via the designer](#adding-the-control-via-the-designer)
+3. [Adding the control manually in XAML](#adding-the-control-manually-in-xaml)
+4. [Adding the control manually in C#](#adding-the-control-manually-in-c)
 
-## Creating project
+## Creating the project
 
-Below section provides detailed information to create new project in Visual Studio to display [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
+The following section provides detailed information to create a new project in Visual Studio to display the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
 
-## Adding control via designer
-The [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control can be added to the application by dragging it from Toolbox and dropping it in designer. The required assembly will be added automatically.
+1. Open Visual Studio and click **File → New → Project**.
+2. Select **WPF App (.NET Framework)** or **WPF Application (.NET)** depending on your target framework.
+3. Name the project **SfRating_GettingStarted** and click **Create**.
+
+## Adding the control via the designer
+The [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control can be added to the application by dragging it from the Toolbox and dropping it in the designer. The required assembly will be added automatically.
+
+1. If the Toolbox is not visible, open it from **View → Toolbox**.
+2. In the Toolbox search box, type **SfRating** and locate the control under the **Syncfusion WPF** tab.
+3. Drag **SfRating** onto the designer surface of `MainWindow.xaml`.
 
 ![Adding Control via Designer in WPF Rating](getting-started-images/wpf-rating-add-control-designer.png)
 
-## Adding control manually in XAML
+## Adding the control manually in XAML
 
-In order to add [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control manually in XAML, do the below steps,
+To add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control manually in XAML, do the following:
 
-1. Add the below required assembly references to the project,
+1. Add the required assembly references to the project:
 
-   * Syncfusion.SfShared.WPF
    * Syncfusion.SfInput.WPF
+   * Syncfusion.SfShared.WPF
+   
+2. Import the Syncfusion WPF schema `http://schemas.syncfusion.com/wpf` in the XAML page.
 
-2. Import Syncfusion<sup>®</sup> WPF schema **http://schemas.syncfusion.com/wpf** in XAML page.
-
-3. Declare [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) in XAML page.
+3. Declare [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) in the XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}
 {% highlight XAML %}
 
-<Window x:Class="SfRating_GettingStarted.MainWindow"
+<Window x:Class="SfRatingSample.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:SfRating_GettingStarted"
+        xmlns:local="clr-namespace:SfRatingSample"
         mc:Ignorable="d"
         Title="SfRating Application" Height="450" Width="800"
         xmlns:syncfusion="http://schemas.syncfusion.com/wpf">
-
     <Grid>
         <syncfusion:SfRating ItemsCount="5" Width="150"/>
     </Grid>
@@ -71,43 +78,43 @@ In order to add [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows
 {% endcapture %}
 {{ codesnippet1 | OrderList_Indent_Level_1 }}
 
-## Add control manually in C#
+## Adding the control manually in C#
 
-In order to add [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control manually in C#, do the below steps,
+To add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control manually in C#, do the following:
 
-1. Add the below required assembly references to the project,
+1. Add the required assembly references to the project:
 
     * Syncfusion.SfShared.WPF
     * Syncfusion.SfInput.WPF
 
-2. Import SfRating namespace **Syncfusion.Windows.Controls.Input**.
+2. Import the SfRating namespace `Syncfusion.Windows.Controls.Input`.
 
-3. Create SfRating control instance and add it to window.
+3. Create an SfRating control instance and add it to the window.
 
 {% capture codesnippet2 %}
 {% tabs %}
 {% highlight C# %}
 
+using System.Windows;
 using Syncfusion.Windows.Controls.Input;
 
-namespace SfRating_GettingStarted
+namespace SfRatingSample
 {
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
     public partial class MainWindow : Window
     {
-        
         public MainWindow()
         {
             InitializeComponent();
-            //Creating an instance of SfRating control. 
-            SfRating newrating = new SfRating()
+            //Creating an instance of the SfRating control.
+            SfRating rating = new SfRating()
             {
                 ItemsCount = 5,
                 Width = 150
             };
-            //Adding SfRating as window content.
+            //Adding SfRating as the window content.
             this.Content = rating;
         }
     }
@@ -118,11 +125,11 @@ namespace SfRating_GettingStarted
 {% endcapture %}
 {{ codesnippet2 | OrderList_Indent_Level_1 }}
 
-## Customize number of rating items
+## Customizing the number of rating items
 
-The number of rating items to be displayed can be customized using [ItemCounts](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_ItemsCount) property in [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
+The number of rating items to be displayed can be customized using the [ItemsCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_ItemsCount) property in the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
 
-N> The default value of ItemsCount is 0.
+N> The default value of `ItemsCount` is `0`, so no items render until you set this property to a positive integer.
 
 {% tabs %}
 
@@ -139,16 +146,17 @@ SfRating rating = new SfRating()
     ItemsCount = 5,
     Width = 150
 };
+this.Content = rating;
 
 {% endhighlight %}
 
 {% endtabs %}
 
-## Set value
+## Setting the value
 
-The display value to be selected among the rating items can be set in the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control using [Value](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_Value) property.
+You can set the selected value among the rating items in the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control using the [Value](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_Value) property. The valid range is `0` to `ItemsCount`.
 
-N> By default, value of this property is 0.
+N> By default, the value of this property is `0`.
 
 {% tabs %}
 
@@ -166,16 +174,17 @@ SfRating rating = new SfRating()
     Width = 150,
     Value = 3
 };
+this.Content = rating
 
 {% endhighlight %}
 
 {% endtabs %}
 
-## Precision of selection
+## Setting the selection precision
 
-The [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control provides option to rate the items in full, half, and exact value using the [Precision](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_Precision) property. 
+The [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control provides options to rate items as full, half, or exact values using the [Precision](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_Precision) property.
 
-N> By default, the value of Precision property is `Standard`.
+N> By default, the value of the `Precision` property is `Standard`.
 
 {% tabs %}
 
@@ -191,10 +200,11 @@ SfRating rating = new SfRating()
 {
     ItemsCount = 5,
     Width = 150,
-    Precision = Syncfusion.Windows.Primitives.Precision.Standard
+    Precision = Syncfusion.Windows.Primitives.Precision.Exact
 };
+this.Content=rating;
 
-{% endhighlight%}
+{% endhighlight %}
 
 {% endtabs %}
 
@@ -204,7 +214,7 @@ SfRating rating = new SfRating()
 
 ## Theme
 
-SfRating supports various built-in themes. Refer to the below links to apply themes for the SfRating,
+SfRating supports various built-in themes. Refer to the links below to apply themes for the SfRating:
 
   * [Apply theme using SfSkinManager](https://help.syncfusion.com/wpf/themes/skin-manager)
 	

--- a/wpf/Rating/Getting-Started.md
+++ b/wpf/Rating/Getting-Started.md
@@ -9,17 +9,18 @@ documentation: ug
 
 # Getting Started with WPF Rating (SfRating)
 
-This section explains how to configure the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control in a real-time scenario and also provides a walk-through on some of the customization features available in the SfRating control.
+This section explains how to get started with the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control and demonstrates some of its basic customization features.
 
 ## Assembly deployment
 
-Refer to the [control dependencies](https://help.syncfusion.com/wpf/control-dependencies#sfrating) section to get the list of assemblies or NuGet package that needs to be added as a reference to use the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control in any application.
+Refer to the [Control Dependencies](https://help.syncfusion.com/wpf/control-dependencies#sfrating) section for the list of assemblies and NuGet packages required to use the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control in a WPF application.
 
-You can find more details about installing the NuGet package in a WPF application in the following link:
+For more information about installing NuGet packages in a WPF application, refer to the following article:
 [How to install nuget packages](https://help.syncfusion.com/wpf/installation/install-nuget-packages)
 
 ## Creating Application with SfRating control
-In this walkthrough, you will create a WPF application that contains the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
+In this walkthrough, you will create a WPF application that hosts the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
+
 1. [Creating the project](#creating-the-project)
 2. [Adding the control via the designer](#adding-the-control-via-the-designer)
 3. [Adding the control manually in XAML](#adding-the-control-manually-in-xaml)
@@ -27,33 +28,33 @@ In this walkthrough, you will create a WPF application that contains the [SfRati
 
 ## Creating the project
 
-The following section provides detailed information to create a new project in Visual Studio to display the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
+The following steps describe how to create a WPF project in Visual Studio and add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control to it.
 
 1. Open Visual Studio and click **File → New → Project**.
 2. Select **WPF App (.NET Framework)** or **WPF Application (.NET)** depending on your target framework.
-3. Name the project **SfRating_GettingStarted** and click **Create**.
+3. Name the project **SfRatingSample** and click **Create**.
 
 ## Adding the control via the designer
-The [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control can be added to the application by dragging it from the Toolbox and dropping it in the designer. The required assembly will be added automatically.
+You can add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control to your application by dragging it from the **Toolbox** and dropping it onto the designer surface. The required assembly references are added automatically.
 
 1. If the Toolbox is not visible, open it from **View → Toolbox**.
 2. In the Toolbox search box, type **SfRating** and locate the control under the **Syncfusion WPF** tab.
 3. Drag **SfRating** onto the designer surface of `MainWindow.xaml`.
 
-![Adding Control via Designer in WPF Rating](getting-started-images/wpf-rating-add-control-designer.png)
+![Adding WPF SfRating Control via Designer](getting-started-images/wpf-rating-add-control-designer.png)
 
 ## Adding the control manually in XAML
 
-To add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control manually in XAML, do the following:
+To add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control manually in XAML, follow these steps:
 
 1. Add the required assembly references to the project:
 
    * Syncfusion.SfInput.WPF
    * Syncfusion.SfShared.WPF
    
-2. Import the Syncfusion WPF schema `http://schemas.syncfusion.com/wpf` in the XAML page.
+2. Import the Syncfusion WPF namespace `http://schemas.syncfusion.com/wpf` in the XAML page.
 
-3. Declare [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) in the XAML page.
+3. Add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control to the XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}
@@ -80,7 +81,7 @@ To add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Cont
 
 ## Adding the control manually in C#
 
-To add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control manually in C#, do the following:
+To add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control manually in C#, follow these steps:
 
 1. Add the required assembly references to the project:
 
@@ -89,7 +90,7 @@ To add the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Cont
 
 2. Import the SfRating namespace `Syncfusion.Windows.Controls.Input`.
 
-3. Create an SfRating control instance and add it to the window.
+3. Create an instance of the SfRating control and add it to the window.
 
 {% capture codesnippet2 %}
 {% tabs %}
@@ -127,7 +128,7 @@ namespace SfRatingSample
 
 ## Customizing the number of rating items
 
-The number of rating items to be displayed can be customized using the [ItemsCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_ItemsCount) property in the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
+Use the [ItemsCount](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_ItemsCount) property to specify the number of rating items displayed in the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control.
 
 N> The default value of `ItemsCount` is `0`, so no items render until you set this property to a positive integer.
 
@@ -146,7 +147,6 @@ SfRating rating = new SfRating()
     ItemsCount = 5,
     Width = 150
 };
-this.Content = rating;
 
 {% endhighlight %}
 
@@ -154,7 +154,7 @@ this.Content = rating;
 
 ## Setting the value
 
-You can set the selected value among the rating items in the [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control using the [Value](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_Value) property. The valid range is `0` to `ItemsCount`.
+Use the [Value](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_Value) property to specify the currently selected rating. The valid range is from 0 to the value specified by _ItemsCount_.
 
 N> By default, the value of this property is `0`.
 
@@ -174,7 +174,6 @@ SfRating rating = new SfRating()
     Width = 150,
     Value = 3
 };
-this.Content = rating
 
 {% endhighlight %}
 
@@ -182,7 +181,7 @@ this.Content = rating
 
 ## Setting the selection precision
 
-The [SfRating](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html) control provides options to rate items as full, half, or exact values using the [Precision](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_Precision) property.
+Use the [Precision](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Input.SfRating.html#Syncfusion_Windows_Controls_Input_SfRating_Precision) property to control whether users can select full, half, or exact rating values.
 
 N> By default, the value of the `Precision` property is `Standard`.
 
@@ -190,7 +189,7 @@ N> By default, the value of the `Precision` property is `Standard`.
 
 {% highlight xaml %}
 
-<syncfusion:SfRating ItemsCount="5" Precision="Exact" Width="150"/>
+<syncfusion:SfRating ItemsCount="5" Value="3" Precision="Exact" Width="150"/>
 	
 {% endhighlight %}
 
@@ -200,24 +199,24 @@ SfRating rating = new SfRating()
 {
     ItemsCount = 5,
     Width = 150,
+	Value = 3,
     Precision = Syncfusion.Windows.Primitives.Precision.Exact
 };
-this.Content=rating;
 
 {% endhighlight %}
 
 {% endtabs %}
 
-![SfRating Getting Started](images/gettingstarted.png)
+![WPF SfRating Control](images/gettingstarted.png)
 
 [View Sample in GitHub](https://github.com/SyncfusionExamples/SfRating-getting-started)
 
 ## Theme
 
-SfRating supports various built-in themes. Refer to the links below to apply themes for the SfRating:
+SfRating supports a variety of built-in themes. Refer to the following articles to learn how to apply themes:
 
   * [Apply theme using SfSkinManager](https://help.syncfusion.com/wpf/themes/skin-manager)
 	
   * [Create a custom theme using ThemeStudio](https://help.syncfusion.com/wpf/themes/theme-studio#creating-custom-theme)
 
-  ![Setting Theme in WPF Rating](getting-started-images/wpf-rating-setting-theme.png)
+![Setting Theme in WPF Rating](getting-started-images/wpf-rating-setting-theme.png)

--- a/wpf/Tile-Control/Getting-Started.md
+++ b/wpf/Tile-Control/Getting-Started.md
@@ -13,11 +13,11 @@ This section gives an overview for working with the Hub Tile and Pulsing Tile co
 
 ## Assembly deployment
 
-Refer [Hub Tile](https://help.syncfusion.com/wpf/control-dependencies#sfhubtile) and [Pulsing Tile](https://help.syncfusion.com/wpf/control-dependencies#sfpulsingtile) control dependencies section to get the list of assemblies or [NuGet package](https://help.syncfusion.com/wpf/visual-studio-integration/nuget-packages) needs to be added as reference to use the Hub Tile and Pulsing Tile control in any application.
+Refer [Hub Tile](https://help.syncfusion.com/wpf/control-dependencies#sfhubtile) and [Pulsing Tile](https://help.syncfusion.com/wpf/control-dependencies#sfpulsingtile) control dependencies section to get the list of assemblies or [NuGet package](https://help.syncfusion.com/wpf/installation/install-nuget-packages) needs to be added as reference to use the Hub Tile and Pulsing Tile control in any application.
 
-## Creating simple application with Hub Tile and Pulsing Tile
+## Creating a simple application with Hub Tile and Pulsing Tile
 
-In this walk through, a WPF application that contains Hub Tile and Pulsing Tile control can be created. By the following ways, the controls can be added: 
+In this walkthrough, a WPF application that contains Hub Tile and Pulsing Tile controls can be created. The controls can be added in the following ways:
 
 1. [Adding control via Designer](#adding-control-via-designer)
 2. [Adding control manually in XAML](#adding-control-manually-in-xaml)
@@ -25,18 +25,18 @@ In this walk through, a WPF application that contains Hub Tile and Pulsing Tile 
 
 ### Adding control via Designer
 
-Hub Tile and Pulsing Tile controls can be added to the application by dragging SfHubTile and SfPulsingTile from toolbox and dropping it in designer view. After dropping the controls in designer view, the assemblies such as **Syncfusion.SfHubTile.WPF** and **Syncfusion.SfShared.WPF** gets added into the project automatically. The following code snippets will also be added to XAML.
+Hub Tile and Pulsing Tile controls can be added to the application by dragging SfHubTile and SfPulsingTile from toolbox and dropping it in designer view. After dropping the controls in designer view, the assemblies such as **Syncfusion.SfHubTile.WPF** and **Syncfusion.SfShared.WPF** get added into the project automatically. The following code snippets will also be added to XAML.
 
 {% tabs %}
 {% highlight XAML %}
 <!--For Hub Tile-->
-<syncfusion:SfHubTile HorizontalAlignment="Left" VerticalAlignment="Top"/>
+<syncfusion:SfHubTile Content="SfHubTile" HorizontalAlignment="Left" VerticalAlignment="Top"/>
 <!--For Pulsing Tile-->
 <syncfusion:SfPulsingTile Content="SfPulsingTile" HorizontalAlignment="Left" VerticalAlignment="Top"/>
 {% endhighlight %}
 {% endtabs %}
 
-N> "syncfusion" in XAML is an auto generated namespace.
+N> `syncfusion` in XAML is an auto-generated namespace.
 
 ![wpf hub tile control added by designer](Getting-Started_images/Hubtile.png)
 
@@ -44,13 +44,13 @@ N> "syncfusion" in XAML is an auto generated namespace.
 	
 ### Adding control manually in XAML
 
-In order to add control manually in XAML, follow the below steps:
+To add the control manually in XAML, follow these steps:
 
-1. Add the below required assembly references to the project.
+1. Add the following required assembly references to the project.
 	* Syncfusion.SfHubTile.WPF
 	* Syncfusion.SfShared.WPF
-2. Import Syncfusion WPF schema `http://schemas.syncfusion.com/wpf` or the tile control namespace `Syncfusion.Windows.Controls.Notification` in XAML page.
-3. Declare SfHubTile and SfPulsingTile controls in XAML page.
+2. Import the Syncfusion WPF schema `http://schemas.syncfusion.com/wpf` or the tile control namespace `Syncfusion.Windows.Controls.Notification` in the XAML page.
+3. Declare `SfHubTile` and `SfPulsingTile` controls in the XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}
@@ -61,11 +61,11 @@ In order to add control manually in XAML, follow the below steps:
 			xmlns:syncfusion="http://schemas.syncfusion.com/wpf" 
 			x:Class="WpfApplication1.MainWindow"
 			Title="MainWindow" Height="350" Width="525">
-	<Grid>
-		  <!--Hub Tile-->
-		  <syncfusion:SfHubTile Content="This is a Hub Tile"/>
-		  <!--Pulsing Tile-->
-		  <syncfusion:SfPulsingTile Content="This is a Pulsing Tile"/>
+	 <Grid x:Name="grid">
+    	<!--Hub Tile-->
+    	<syncfusion:SfHubTile Content="This is a Hub Tile" HorizontalAlignment="Left"/>
+    	<!--Pulsing Tile-->
+    	<syncfusion:SfPulsingTile Content="This is a Pulsing Tile" HorizontalAlignment="Right"/>
 	</Grid>
 </Window>
 
@@ -76,30 +76,19 @@ In order to add control manually in XAML, follow the below steps:
 
 ### Adding control manually in C#
 
-In order to add control manually in C#, follow the below steps:
+To add the control manually in C#, follow these steps:
 
-1. Add the below required assembly references to the project.
+1. Add the following required assembly references to the project.
 	* Syncfusion.SfHubTile.WPF
 	* Syncfusion.SfShared.WPF
 2. Import the `Syncfusion.Windows.Controls.Notification` namespace.
-3. Create SfHubTile and SfPulsingTile controls instance and add it to the window.
+3. Create instances of `SfHubTile` and `SfPulsingTile` and add them to the window.
 
 {% capture codesnippet2 %}
-{% tabs %}
-{% highlight XAML %}
-<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        x:Class="WpfApplication1.MainWindow"
-        Title="MainWindow" Height="350" Width="525">
-	<Grid x:Name="grid">
-	</Grid>
-</Window>
-
-{% endhighlight %}
 {% highlight C# %}
 
 using Syncfusion.Windows.Controls.Notification;
-namespace SfHubTileSample
+namespace WpfApplication1
 {	
 	public partial class MainWindow : Window
 	{
@@ -108,9 +97,14 @@ namespace SfHubTileSample
 			InitializeComponent();
 			// Hub Tile
 			SfHubTile hubTile = new SfHubTile();
+			hubTile.Content="This is a Hub Tile";
+			hubTile.HorizontalAlignment = HorizontalAlignment.Left;
 			grid.Children.Add(hubTile);
+
 			//Pulsing Tile
 			SfPulsingTile pulseTile = new SfPulsingTile();
+			pulseTile.Content="This is a Pulsing Tile";
+			pulseTile.HorizontalAlignment = HorizontalAlignment.Right;
 			grid.Children.Add(pulseTile);
 		}
 	}
@@ -121,7 +115,7 @@ namespace SfHubTileSample
 {% endcapture %}
 {{ codesnippet2 | OrderList_Indent_Level_1 }}
 
-## Setting title, header and image in tile
+## Setting Title, Header, and Image in the Tile
 
 The title, header and image for the tile can be set by using [Title](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Notification.HubTileBase.html#Syncfusion_Windows_Controls_Notification_HubTileBase_Title), [Header](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Primitives.HeaderedContentControl.html#Syncfusion_Windows_Primitives_HeaderedContentControl_Header) and [ImageSource](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Notification.HubTileBase.html#Syncfusion_Windows_Controls_Notification_HubTileBase_ImageSource) properties respectively.
 
@@ -135,14 +129,13 @@ Hub Tile
 Pulsing Tile
 {:.caption}
 
-N> The title will be displayed at the top of the tile. The header will be displayed at the bottom of the tile. The image will be displayed at the center of the tile.
+N> The title is displayed at the top of the tile, the header is displayed at the bottom of the tile, and the image is displayed at the center of the tile.
 
 ## Theme
 
-Hub Tile and Pulsing Tile controls supports various built-in themes. Refer to the below links to apply themes for the Hub Tile and Pulsing Tile,
+Hub Tile and Pulsing Tile controls support various built-in themes. Refer to the following links to apply themes to the Hub Tile and Pulsing Tile:
 
   * [Apply theme using SfSkinManager](https://help.syncfusion.com/wpf/themes/skin-manager)
-	
   * [Create a custom theme using ThemeStudio](https://help.syncfusion.com/wpf/themes/theme-studio#creating-custom-theme)
 
   ![Setting theme to WPF Hub Tile and Pulsing Tile controls](Getting-Started_images/Theme.png)

--- a/wpf/Tile-Control/Getting-Started.md
+++ b/wpf/Tile-Control/Getting-Started.md
@@ -111,7 +111,6 @@ namespace WpfApplication1
 }
 
 {% endhighlight %}
-{% endtabs %}
 {% endcapture %}
 {{ codesnippet2 | OrderList_Indent_Level_1 }}
 

--- a/wpf/Tile-Control/Getting-Started.md
+++ b/wpf/Tile-Control/Getting-Started.md
@@ -2,7 +2,7 @@
 layout: post
 title: Getting Started with WPF Tile Control | Syncfusion
 description: Learn here about getting started with Syncfusion Essential Studio WPF Tile Control, its elements and more.
-platform: WPF
+platform: wpf
 control: SfHubTile
 documentation: ug
 ---

--- a/wpf/Tile-Control/Getting-Started.md
+++ b/wpf/Tile-Control/Getting-Started.md
@@ -9,15 +9,15 @@ documentation: ug
 
 # Getting Started with WPF Tile Control
 
-This section gives an overview for working with the Hub Tile and Pulsing Tile controls.
+This section explains how to get started with the Hub Tile and Pulsing Tile controls in a WPF application.
 
 ## Assembly deployment
 
-Refer [Hub Tile](https://help.syncfusion.com/wpf/control-dependencies#sfhubtile) and [Pulsing Tile](https://help.syncfusion.com/wpf/control-dependencies#sfpulsingtile) control dependencies section to get the list of assemblies or [NuGet package](https://help.syncfusion.com/wpf/installation/install-nuget-packages) needs to be added as reference to use the Hub Tile and Pulsing Tile control in any application.
+Refer to the [Hub Tile](https://help.syncfusion.com/wpf/control-dependencies#sfhubtile) and [Pulsing Tile](https://help.syncfusion.com/wpf/control-dependencies#sfpulsingtile) control dependencies sections for the list of assemblies and [NuGet package](https://help.syncfusion.com/wpf/installation/install-nuget-packages) required to use these controls in a WPF application.
 
 ## Creating a simple application with Hub Tile and Pulsing Tile
 
-In this walkthrough, a WPF application that contains Hub Tile and Pulsing Tile controls can be created. The controls can be added in the following ways:
+In this walkthrough, you will create a WPF application that contains Hub Tile and Pulsing Tile controls.
 
 1. [Adding control via Designer](#adding-control-via-designer)
 2. [Adding control manually in XAML](#adding-control-manually-in-xaml)
@@ -25,7 +25,7 @@ In this walkthrough, a WPF application that contains Hub Tile and Pulsing Tile c
 
 ### Adding control via Designer
 
-Hub Tile and Pulsing Tile controls can be added to the application by dragging SfHubTile and SfPulsingTile from toolbox and dropping it in designer view. After dropping the controls in designer view, the assemblies such as **Syncfusion.SfHubTile.WPF** and **Syncfusion.SfShared.WPF** get added into the project automatically. The following code snippets will also be added to XAML.
+You can add the Hub Tile and Pulsing Tile controls to your application by dragging SfHubTile and SfPulsingTile from the Toolbox and dropping them onto the designer surface. When you add the controls through the designer, the required assemblies, such as **Syncfusion.SfHubTile.WPF** and **Syncfusion.SfShared.WPF**, are automatically added to the project. The following XAML code is generated automatically.
 
 {% tabs %}
 {% highlight XAML %}
@@ -44,13 +44,13 @@ N> `syncfusion` in XAML is an auto-generated namespace.
 	
 ### Adding control manually in XAML
 
-To add the control manually in XAML, follow these steps:
+To add the controls manually in XAML, follow these steps:
 
 1. Add the following required assembly references to the project.
 	* Syncfusion.SfHubTile.WPF
 	* Syncfusion.SfShared.WPF
-2. Import the Syncfusion WPF schema `http://schemas.syncfusion.com/wpf` or the tile control namespace `Syncfusion.Windows.Controls.Notification` in the XAML page.
-3. Declare `SfHubTile` and `SfPulsingTile` controls in the XAML page.
+2. Import the Syncfusion WPF schema `http://schemas.syncfusion.com/wpf` or the control namespace `Syncfusion.Windows.Controls.Notification` in the XAML page.
+3. Add the SfHubTile and SfPulsingTile controls to the XAML page.
 
 {% capture codesnippet1 %}
 {% tabs %}
@@ -82,7 +82,7 @@ To add the control manually in C#, follow these steps:
 	* Syncfusion.SfHubTile.WPF
 	* Syncfusion.SfShared.WPF
 2. Import the `Syncfusion.Windows.Controls.Notification` namespace.
-3. Create instances of `SfHubTile` and `SfPulsingTile` and add them to the window.
+3. Create instances of SfHubTile and SfPulsingTile, and then add them to the layout container.
 
 {% capture codesnippet2 %}
 {% highlight C# %}
@@ -116,25 +116,25 @@ namespace WpfApplication1
 
 ## Setting Title, Header, and Image in the Tile
 
-The title, header and image for the tile can be set by using [Title](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Notification.HubTileBase.html#Syncfusion_Windows_Controls_Notification_HubTileBase_Title), [Header](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Primitives.HeaderedContentControl.html#Syncfusion_Windows_Primitives_HeaderedContentControl_Header) and [ImageSource](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Notification.HubTileBase.html#Syncfusion_Windows_Controls_Notification_HubTileBase_ImageSource) properties respectively.
+Use the [Title](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Notification.HubTileBase.html#Syncfusion_Windows_Controls_Notification_HubTileBase_Title), [Header](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Primitives.HeaderedContentControl.html#Syncfusion_Windows_Primitives_HeaderedContentControl_Header) and [ImageSource](https://help.syncfusion.com/cr/wpf/Syncfusion.Windows.Controls.Notification.HubTileBase.html#Syncfusion_Windows_Controls_Notification_HubTileBase_ImageSource) properties to specify the title, header, and image displayed in the tile.
 
-![wpf hub tile structure](Getting-Started_images/wpf-hubtile.png)
+![WPF Hub Tile Structure](Getting-Started_images/wpf-hubtile.png)
 
 Hub Tile
 {:.caption}
 
-![wpf pulsing tile structure](Getting-Started_images/pulsingtile-image.png)
+![WPF Pulsing Tile Structure](Getting-Started_images/pulsingtile-image.png)
 
 Pulsing Tile
 {:.caption}
 
-N> The title is displayed at the top of the tile, the header is displayed at the bottom of the tile, and the image is displayed at the center of the tile.
+N> The title is displayed at the top of the tile, the header is displayed at the bottom, and the image is displayed in the center.
 
 ## Theme
 
-Hub Tile and Pulsing Tile controls support various built-in themes. Refer to the following links to apply themes to the Hub Tile and Pulsing Tile:
+Hub Tile and Pulsing Tile controls support a variety of built-in themes. Refer to the following articles to learn how to apply themes to the Hub Tile and Pulsing Tile controls:
 
   * [Apply theme using SfSkinManager](https://help.syncfusion.com/wpf/themes/skin-manager)
   * [Create a custom theme using ThemeStudio](https://help.syncfusion.com/wpf/themes/theme-studio#creating-custom-theme)
 
-  ![Setting theme to WPF Hub Tile and Pulsing Tile controls](Getting-Started_images/Theme.png)
+![Setting theme to WPF Hub Tile and Pulsing Tile controls](Getting-Started_images/Theme.png)


### PR DESCRIPTION
### Task Description ###
[Task 1046078](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/1046078/): Fix the getting started documentation issue for tools controls in WPF platform.

### Description ###
Updated the UG Documentation for the GettingStarted page for below controls:

- RatingControl.
- TileControl(HubTile and PulsingTile).

### AI Usage ###

<b>Code Studio used in this PR/MR?</b>

* [x] Yes
* [ ] No

If <b>Yes</b>: Primary use (choose one)

* [ ] Generate new code
* [ ] Refactor/improve existing code
* [ ] Tests
* [ ] Bug fix / debugging help
* [x] Docs / comments
* [ ] Review assistance (explanations/summaries)
* [ ] Other

<b>Outcome</b>
* [x] Saved time (AI made development faster)
* [ ] Neutral (No major difference)
* [ ] Cost time (AI slowed things down)
 
If <b>Cost time</b>: Provide one line explanation